### PR TITLE
feat: change the boot order to be first disk, then network

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -20,7 +20,9 @@ import (
 
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/constants"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/ipxe"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/meta"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/power/pxe"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/version"
 )
 
@@ -124,7 +126,11 @@ func init() {
 		"The directory to read the power management API endpoints and ports, to be used to manage the power state of the machines which are managed via API "+
 			"(e.g., QEMU VMs created by 'qemu-up' or 'talosctl cluster create') Mainly used for testing purposes.")
 	rootCmd.Flags().StringVar(&providerOptions.BootFromDiskMethod, "boot-from-disk-method", provider.DefaultOptions.BootFromDiskMethod,
-		"Default method to use to boot server from disk if it hits iPXE endpoint after install.")
+		fmt.Sprintf("Default method to use to boot server from disk if it hits iPXE endpoint after install. Valid values are: %v",
+			[]ipxe.BootFromDiskMethod{ipxe.BootIPXEExit, ipxe.Boot404, ipxe.BootSANDisk}))
+	rootCmd.Flags().StringVar(&providerOptions.IPMIPXEBootMode, "ipmi-pxe-boot-mode", provider.DefaultOptions.IPMIPXEBootMode,
+		fmt.Sprintf("Default boot mode to use when PXE booting a machine via IPMI. Valid values are: %v",
+			[]pxe.BootMode{pxe.BootModeBIOS, pxe.BootModeUEFI}))
 	rootCmd.Flags().StringSliceVar(&providerOptions.MachineLabels, "machine-labels", provider.DefaultOptions.MachineLabels,
 		"Comma separated list of key=value pairs to be set to the machine. Example: key1=value1,key2,key3=value3")
 	rootCmd.Flags().BoolVar(&providerOptions.InsecureSkipTLSVerify, "insecure-skip-tls-verify", provider.DefaultOptions.InsecureSkipTLSVerify,

--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -181,6 +181,7 @@ docker run -d --network host \
   --use-local-boot-assets \
   --agent-test-mode \
   --api-power-mgmt-state-dir=/api-power-mgmt-state \
+  --ipmi-pxe-boot-mode=bios \
   --debug
 
 docker logs -f provider &

--- a/internal/provider/options.go
+++ b/internal/provider/options.go
@@ -4,7 +4,10 @@
 
 package provider
 
-import "github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/ipxe"
+import (
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/ipxe"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/power/pxe"
+)
 
 // Options contains the provider options.
 type Options struct {
@@ -19,6 +22,7 @@ type Options struct {
 	APIPowerMgmtStateDir   string
 	DHCPProxyIfaceOrIP     string
 	BootFromDiskMethod     string
+	IPMIPXEBootMode        string
 	MachineLabels          []string
 	APIPort                int
 
@@ -38,5 +42,6 @@ var DefaultOptions = Options{
 	ImageFactoryPXEBaseURL: "https://pxe.factory.talos.dev",
 	AgentModeTalosVersion:  "v1.9.0-alpha.2",
 	BootFromDiskMethod:     string(ipxe.BootIPXEExit),
+	IPMIPXEBootMode:        string(pxe.BootModeUEFI),
 	APIPort:                50042,
 }

--- a/internal/provider/power/api/api.go
+++ b/internal/provider/power/api/api.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/siderolabs/omni-infra-provider-bare-metal/api/specs"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/power/pxe"
 )
 
 // Client is an API power management client: it communicates with an HTTP API to send power management commands.
@@ -34,6 +35,11 @@ func (c *Client) Reboot(ctx context.Context) error {
 // PowerOff implements the power.Client interface.
 func (c *Client) PowerOff(ctx context.Context) error {
 	return c.doPost(ctx, "/poweroff")
+}
+
+// SetPXEBootOnce implements the power.Client interface.
+func (c *Client) SetPXEBootOnce(ctx context.Context, _ pxe.BootMode) error {
+	return c.doPost(ctx, "/pxeboot")
 }
 
 func (c *Client) doPost(ctx context.Context, path string) error {

--- a/internal/provider/power/ipmi/ipmi.go
+++ b/internal/provider/power/ipmi/ipmi.go
@@ -7,10 +7,12 @@ package ipmi
 
 import (
 	"context"
+	"fmt"
 
 	goipmi "github.com/pensando/goipmi"
 
 	"github.com/siderolabs/omni-infra-provider-bare-metal/api/specs"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/power/pxe"
 )
 
 const ipmiUsername = "talos-agent"
@@ -33,6 +35,18 @@ func (c *Client) Reboot(context.Context) error {
 // PowerOff implements the power.Client interface.
 func (c *Client) PowerOff(context.Context) error {
 	return c.ipmiClient.Control(goipmi.ControlPowerDown)
+}
+
+// SetPXEBootOnce implements the power.Client interface.
+func (c *Client) SetPXEBootOnce(_ context.Context, mode pxe.BootMode) error {
+	switch mode {
+	case pxe.BootModeBIOS:
+		return c.ipmiClient.SetBootDevice(goipmi.BootDevicePxe)
+	case pxe.BootModeUEFI:
+		return c.ipmiClient.SetBootDeviceEFI(goipmi.BootDevicePxe)
+	default:
+		return fmt.Errorf("unsupported mode %q", mode)
+	}
 }
 
 // IsPoweredOn implements the power.Client interface.

--- a/internal/provider/power/power.go
+++ b/internal/provider/power/power.go
@@ -13,6 +13,7 @@ import (
 	"github.com/siderolabs/omni-infra-provider-bare-metal/api/specs"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/power/api"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/power/ipmi"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/power/pxe"
 )
 
 // ErrNoPowerManagementInfo is returned when there is no power management info present yet for a machine.
@@ -24,6 +25,7 @@ type Client interface {
 	Reboot(ctx context.Context) error
 	IsPoweredOn(ctx context.Context) (bool, error)
 	PowerOff(ctx context.Context) error
+	SetPXEBootOnce(ctx context.Context, mode pxe.BootMode) error
 }
 
 // GetClient returns a power management client for the given bare metal machine.

--- a/internal/provider/power/pxe/pxe.go
+++ b/internal/provider/power/pxe/pxe.go
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package pxe contains types related to PXE booting.
+package pxe
+
+import "fmt"
+
+// BootMode is the PXE boot mode to be used.
+type BootMode string
+
+const (
+	// BootModeBIOS is the mode to boot from disk using BIOS.
+	BootModeBIOS BootMode = "bios"
+
+	// BootModeUEFI is the mode to boot from disk using UEFI.
+	BootModeUEFI BootMode = "uefi"
+)
+
+// ParseBootMode parses a boot mode.
+func ParseBootMode(mode string) (BootMode, error) {
+	switch mode {
+	case string(BootModeBIOS):
+		return BootModeBIOS, nil
+	case string(BootModeUEFI):
+		return BootModeUEFI, nil
+	default:
+		return "", fmt.Errorf("unknown boot mode: %s", mode)
+	}
+}

--- a/internal/qemu/machines.go
+++ b/internal/qemu/machines.go
@@ -201,7 +201,7 @@ func (machines *Machines) createNew(ctx context.Context, qemuProvisioner provisi
 			SkipInjectingConfig: true,
 			UUID:                &nodeUUID,
 			PXEBooted:           true,
-			DefaultBootOrder:    "nc", // first network, then disk
+			DefaultBootOrder:    "cn", // first disk, then network
 		})
 	}
 


### PR DESCRIPTION
With this change, the machines' boot order is expected to be configured as first disk, then network.

When the provider needs to boot a machine via PXE, it sets its next boot to be a PXE boot using IPMI/API.

Closes https://github.com/siderolabs/omni/issues/761

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>