### PR TITLE
feat: set machine labels directly on `InfraMachineStatus`

### DIFF
--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -183,6 +183,7 @@ docker run -d --network host \
   --api-power-mgmt-state-dir=/api-power-mgmt-state \
   --ipmi-pxe-boot-mode=bios \
   --min-reboot-interval=1m \
+  --machine-labels=a=b,c \
   --debug
 
 docker logs -f provider &

--- a/internal/provider/imagefactory/client.go
+++ b/internal/provider/imagefactory/client.go
@@ -7,13 +7,10 @@ package imagefactory
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/siderolabs/image-factory/pkg/client"
 	"github.com/siderolabs/image-factory/pkg/schematic"
-	"github.com/siderolabs/omni/client/pkg/meta"
-	"gopkg.in/yaml.v3"
 )
 
 var agentModeExtensions = []string{
@@ -36,16 +33,10 @@ type Client struct {
 	factoryClient         *client.Client
 	pxeBaseURL            string
 	agentModeTalosVersion string
-	machineLabelsMeta     string
 }
 
 // NewClient creates a new image factory client.
-func NewClient(baseURL, pxeBaseURL, agentModeTalosVersion string, machineLabels []string) (*Client, error) {
-	labelsMeta, err := parseLabels(machineLabels)
-	if err != nil {
-		return nil, err
-	}
-
+func NewClient(baseURL, pxeBaseURL, agentModeTalosVersion string) (*Client, error) {
 	factoryClient, err := client.New(baseURL)
 	if err != nil {
 		return nil, err
@@ -54,9 +45,7 @@ func NewClient(baseURL, pxeBaseURL, agentModeTalosVersion string, machineLabels 
 	return &Client{
 		pxeBaseURL:            pxeBaseURL,
 		agentModeTalosVersion: agentModeTalosVersion,
-		machineLabelsMeta:     labelsMeta,
-
-		factoryClient: factoryClient,
+		factoryClient:         factoryClient,
 	}, nil
 }
 
@@ -65,13 +54,6 @@ func NewClient(baseURL, pxeBaseURL, agentModeTalosVersion string, machineLabels 
 // If agentMode is true, the schematic will be created with the firmware extensions and the metal-agent extension.
 func (c *Client) SchematicIPXEURL(ctx context.Context, agentMode bool, talosVersion, arch string, extensions, extraKernelArgs []string) (string, error) {
 	var metaValues []schematic.MetaValue
-
-	if c.machineLabelsMeta != "" {
-		metaValues = append(metaValues, schematic.MetaValue{
-			Key:   meta.LabelsMeta,
-			Value: c.machineLabelsMeta,
-		})
-	}
 
 	if !agentMode && talosVersion == "" {
 		return "", fmt.Errorf("talosVersion is required when not booting into agent mode")
@@ -104,32 +86,4 @@ func (c *Client) SchematicIPXEURL(ctx context.Context, agentMode bool, talosVers
 	ipxeURL := fmt.Sprintf("%s/pxe/%s/%s/metal-%s", c.pxeBaseURL, schematicID, talosVersion, arch)
 
 	return ipxeURL, err
-}
-
-func parseLabels(machineLabels []string) (string, error) {
-	labels := map[string]string{}
-
-	for _, l := range machineLabels {
-		parts := strings.Split(l, "=")
-		if len(parts) > 2 {
-			return "", fmt.Errorf("malformed label %s", l)
-		}
-
-		value := ""
-
-		if len(parts) > 1 {
-			value = parts[1]
-		}
-
-		labels[parts[0]] = value
-	}
-
-	data, err := yaml.Marshal(meta.ImageLabels{
-		Labels: labels,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return string(data), nil
 }


### PR DESCRIPTION
We do not need to set initial machine labels via META values: as the provider has access to Omni, it can write these labels directly to the resources in creates on Omni side.