### PR TITLE
feat: ignore rejected and cordoned machines in pxe boot handler

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -146,6 +146,8 @@ func init() {
 		"Enable controller runtime resource cache.")
 	rootCmd.Flags().BoolVar(&providerOptions.WipeWithZeroes, "wipe-with-zeroes", provider.DefaultOptions.WipeWithZeroes,
 		"When wiping a machine, write zeroes to the whole disk instead doing a fast wipe.")
+	rootCmd.Flags().BoolVar(&providerOptions.DisableDHCPProxy, "disable-dhcp-proxy", provider.DefaultOptions.DisableDHCPProxy,
+		"Disable the DHCP proxy server.")
 
 	// RedFish options
 	rootCmd.Flags().BoolVar(&providerOptions.RedfishOptions.UseAlways, "redfish-use-always", provider.DefaultOptions.RedfishOptions.UseAlways,

--- a/internal/provider/controllers/power_operation.go
+++ b/internal/provider/controllers/power_operation.go
@@ -62,7 +62,7 @@ type powerOperationControllerHelper struct {
 	minRebootInterval time.Duration
 }
 
-//nolint:gocyclo,cyclop
+//nolint:cyclop
 func (helper *powerOperationControllerHelper) transform(ctx context.Context, r controller.ReaderWriter, logger *zap.Logger,
 	infraMachine *infra.Machine, powerOperation *resources.PowerOperation,
 ) error {
@@ -149,8 +149,6 @@ func (helper *powerOperationControllerHelper) transform(ctx context.Context, r c
 		}
 
 		powerOperation.TypedSpec().Value.LastPowerOperation = specs.PowerState_POWER_STATE_OFF
-	case infraMachine.TypedSpec().Value.Cordoned:
-		logger.Debug("machine is cordoned, skip power management")
 	default:
 		logger.Debug("machine power state is already as desired")
 	}

--- a/internal/provider/options.go
+++ b/internal/provider/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	UseLocalBootAssets    bool
 	ClearState            bool
 	WipeWithZeroes        bool
+	DisableDHCPProxy      bool
 
 	RedfishOptions redfish.Options
 


### PR DESCRIPTION
Return 404 for such machines, so they make their own decision/fallback.

Also add an option to disable DHCP proxy.

Do some minor logging improvements.

Closes https://github.com/siderolabs/omni/issues/869.