### PR TITLE
fix: serve iPXE binaries over http

### DIFF
--- a/internal/provider/dhcp/proxy.go
+++ b/internal/provider/dhcp/proxy.go
@@ -253,10 +253,10 @@ func offerDHCP(req *dhcpv4.DHCPv4, apiAdvertiseAddress string, apiPort int, fwty
 		resp.UpdateOption(dhcpv4.OptBootFileName("snp-arm64.efi"))
 	case FirmwareX86HTTP:
 		// This is completely standard HTTP-boot: just load a file from HTTP.
-		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("http://%s/tftp/snp.efi", ipPort)))
+		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("http://%s/tftp/amd64/snp.efi", ipPort)))
 	case FirmwareARMHTTP:
 		// This is completely standard HTTP-boot: just load a file from HTTP.
-		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("http://%s/tftp/snp-arm64.efi", ipPort)))
+		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("http://%s/tftp/arm64/snp.efi", ipPort)))
 	case FirmwareUnsupported:
 		fallthrough
 	default:

--- a/internal/provider/server/server.go
+++ b/internal/provider/server/server.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/constants"
 	providertls "github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/tls"
 )
 
@@ -147,6 +148,7 @@ func newMultiHandler(configHandler, ipxeHandler, grpcHandler http.Handler, serve
 
 	mux.Handle("/config", configHandler)
 	mux.Handle("/ipxe", ipxeHandler)
+	mux.Handle("/tftp/", http.StripPrefix("/tftp/", http.FileServer(http.Dir(constants.IPXEPath+"/"))))
 
 	if serveAssetsDir {
 		mux.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("/assets/"))))


### PR DESCRIPTION
There are firmwares that require iPXE artifacts to be served over HTTP. We were retuning a DHCP response to them with a URL, but the files were not served on that URL.

Serve these files so the iPXE process can succeed on those machines.