### PR TITLE
fix: make tftp server bind on api listen address

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -178,7 +178,7 @@ func (p *Provider) Run(ctx context.Context) error {
 	bmcClientFactory := bmc.NewClientFactory(bmc.ClientFactoryOptions{
 		RedfishOptions: p.options.Redfish,
 	}, p.logger)
-	tftpServer := tftp.NewServer(p.logger.With(zap.String("component", "tftp_server")))
+	tftpServer := tftp.NewServer(p.options.APIListenAddress, p.logger.With(zap.String("component", "tftp_server")))
 	bmcAPIAddressReader := bmcapi.NewAddressReader(p.options.APIPowerMgmtStateDir)
 	agentClient := agent.NewClient(agentConnectionEventCh, p.options.WipeWithZeroes, p.logger.With(zap.String("component", "agent_client"))) //nolint:contextcheck // false positive
 	srvr := server.New(ctx, p.options.APIListenAddress, p.options.APIPort, p.options.TLS.APIPort, p.options.UseLocalBootAssets, certs, configHandler, ipxeHandler,

--- a/internal/provider/tftp/tftp_server.go
+++ b/internal/provider/tftp/tftp_server.go
@@ -8,6 +8,7 @@ package tftp
 import (
 	"context"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -23,12 +24,15 @@ import (
 // Server represents the TFTP server serving iPXE binaries.
 type Server struct {
 	logger *zap.Logger
+
+	listenAddress string
 }
 
 // NewServer creates a new TFTP server.
-func NewServer(logger *zap.Logger) *Server {
+func NewServer(listenAddress string, logger *zap.Logger) *Server {
 	return &Server{
-		logger: logger,
+		listenAddress: listenAddress,
+		logger:        logger,
 	}
 }
 
@@ -56,7 +60,7 @@ func (s *Server) Run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		return srv.ListenAndServe(":69")
+		return srv.ListenAndServe(net.JoinHostPort(s.listenAddress, "69"))
 	})
 
 	eg.Go(func() error {


### PR DESCRIPTION
So that we can run multiple instances of the provider on the same server.