### PR TITLE
feat: allow configuring agent calls/wipe timeouts

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	providerOptions provider.Options
+	providerOptions = provider.DefaultOptions()
 	debug           bool
 )
 
@@ -96,82 +96,90 @@ func init() {
 	rootCmd.Flags().Var(&meta.ProviderID, "id", "The id of the infra provider, it is used to match the resources with the infra provider label.")
 	rootCmd.Flags().BoolVar(&debug, "debug", false, "Enable debug mode & logs.")
 
-	rootCmd.Flags().StringVar(&providerOptions.APIListenAddress, "api-listen-address", provider.DefaultOptions.APIListenAddress,
+	rootCmd.Flags().StringVar(&providerOptions.APIListenAddress, "api-listen-address", providerOptions.APIListenAddress,
 		"The IP address to listen on. If not specified, the server will listen on all interfaces.")
-	rootCmd.Flags().StringVar(&providerOptions.APIAdvertiseAddress, "api-advertise-address", provider.DefaultOptions.APIAdvertiseAddress,
+	rootCmd.Flags().StringVar(&providerOptions.APIAdvertiseAddress, "api-advertise-address", providerOptions.APIAdvertiseAddress,
 		"The IP address to advertise. Required if the server has more than a single routable IP address. If not specified, the single routable IP address will be used.")
-	rootCmd.Flags().IntVar(&providerOptions.APIPort, "api-port", provider.DefaultOptions.APIPort, "The port to run the api server on.")
+	rootCmd.Flags().IntVar(&providerOptions.APIPort, "api-port", providerOptions.APIPort, "The port to run the api server on.")
 	rootCmd.Flags().StringVar(&providerOptions.OmniAPIEndpoint, "omni-api-endpoint", os.Getenv("OMNI_ENDPOINT"),
 		"The endpoint of the Omni API, if not set, defaults to OMNI_ENDPOINT env var.")
-	rootCmd.Flags().StringVar(&providerOptions.Name, "provider-name", provider.DefaultOptions.Name, "Provider name as it appears in Omni")
-	rootCmd.Flags().StringVar(&providerOptions.Description, "provider-description", provider.DefaultOptions.Description, "Provider description as it appears in Omni")
-	rootCmd.Flags().BoolVar(&providerOptions.UseLocalBootAssets, "use-local-boot-assets", provider.DefaultOptions.UseLocalBootAssets,
+	rootCmd.Flags().StringVar(&providerOptions.Name, "provider-name", providerOptions.Name, "Provider name as it appears in Omni")
+	rootCmd.Flags().StringVar(&providerOptions.Description, "provider-description", providerOptions.Description, "Provider description as it appears in Omni")
+	rootCmd.Flags().BoolVar(&providerOptions.UseLocalBootAssets, "use-local-boot-assets", providerOptions.UseLocalBootAssets,
 		"Use local boot assets for iPXE booting. If set, the iPXE server will use the kernel and initramfs from the local assets "+
 			"instead of forwarding the request to the image factory to boot into agent mode.")
-	rootCmd.Flags().StringVar(&providerOptions.DHCPProxyIfaceOrIP, "dhcp-proxy-iface-or-ip", provider.DefaultOptions.DHCPProxyIfaceOrIP,
+	rootCmd.Flags().StringVar(&providerOptions.DHCPProxyIfaceOrIP, "dhcp-proxy-iface-or-ip", providerOptions.DHCPProxyIfaceOrIP,
 		"The interface name or the IP address on the interface to run the DHCP proxy server on. "+
 			"If it is an IP address, the DHCP proxy server will run on the interface that has the IP address. "+
 			"If not specified, defaults to the API advertise address.")
-	rootCmd.Flags().StringVar(&providerOptions.ImageFactoryBaseURL, "image-factory-base-url", provider.DefaultOptions.ImageFactoryBaseURL,
+	rootCmd.Flags().StringVar(&providerOptions.ImageFactoryBaseURL, "image-factory-base-url", providerOptions.ImageFactoryBaseURL,
 		"The base URL of the image factory.")
-	rootCmd.Flags().StringVar(&providerOptions.ImageFactoryPXEBaseURL, "image-factory-pxe-base-url", provider.DefaultOptions.ImageFactoryPXEBaseURL,
+	rootCmd.Flags().StringVar(&providerOptions.ImageFactoryPXEBaseURL, "image-factory-pxe-base-url", providerOptions.ImageFactoryPXEBaseURL,
 		"The base URL of the image factory PXE server.")
-	rootCmd.Flags().StringVar(&providerOptions.AgentModeTalosVersion, "agent-mode-talos-version", provider.DefaultOptions.AgentModeTalosVersion,
+	rootCmd.Flags().StringVar(&providerOptions.AgentModeTalosVersion, "agent-mode-talos-version", providerOptions.AgentModeTalosVersion,
 		"The default Talos version to when forwarding iPXE requests to the image factory to boot into Talos agent.")
-	rootCmd.Flags().BoolVar(&providerOptions.AgentTestMode, "agent-test-mode", provider.DefaultOptions.AgentTestMode,
+	rootCmd.Flags().BoolVar(&providerOptions.AgentTestMode, "agent-test-mode", providerOptions.AgentTestMode,
 		fmt.Sprintf("Enable agent test mode. In this mode, the Talos agent will be booted into the test mode via the kernel arg %q. "+
 			`In this mode, you probably want to set the "--%s" flag, as the test mode agents are probably QEMU machines whose power is managed over the HTTP API.`,
 			config.TestModeKernelArg, apiPowerMgmtStateDirFlag))
-	rootCmd.Flags().StringVar(&providerOptions.APIPowerMgmtStateDir, apiPowerMgmtStateDirFlag, provider.DefaultOptions.APIPowerMgmtStateDir,
+	rootCmd.Flags().StringVar(&providerOptions.APIPowerMgmtStateDir, apiPowerMgmtStateDirFlag, providerOptions.APIPowerMgmtStateDir,
 		"The directory to read the power management API endpoints and ports, to be used to manage the power state of the machines which are managed via API "+
 			"(e.g., QEMU VMs created by 'qemu-up' or 'talosctl cluster create') Mainly used for testing purposes.")
-	rootCmd.Flags().StringVar(&providerOptions.BootFromDiskMethod, "boot-from-disk-method", provider.DefaultOptions.BootFromDiskMethod,
+	rootCmd.Flags().StringVar(&providerOptions.BootFromDiskMethod, "boot-from-disk-method", providerOptions.BootFromDiskMethod,
 		fmt.Sprintf("Default method to use to boot server from disk if it hits iPXE endpoint after install. Valid values are: %v",
 			[]ipxe.BootFromDiskMethod{ipxe.BootIPXEExit, ipxe.Boot404, ipxe.BootSANDisk}))
-	rootCmd.Flags().StringVar(&providerOptions.IPMIPXEBootMode, "ipmi-pxe-boot-mode", provider.DefaultOptions.IPMIPXEBootMode,
+	rootCmd.Flags().StringVar(&providerOptions.IPMIPXEBootMode, "ipmi-pxe-boot-mode", providerOptions.IPMIPXEBootMode,
 		fmt.Sprintf("Default boot mode to use when PXE booting a machine via IPMI. Valid values are: %v",
 			[]pxe.BootMode{pxe.BootModeBIOS, pxe.BootModeUEFI}))
-	rootCmd.Flags().StringSliceVar(&providerOptions.MachineLabels, "machine-labels", provider.DefaultOptions.MachineLabels,
+	rootCmd.Flags().StringSliceVar(&providerOptions.MachineLabels, "machine-labels", providerOptions.MachineLabels,
 		"Comma separated list of key=value pairs to be set to the machine. Example: key1=value1,key2,key3=value3")
-	rootCmd.Flags().BoolVar(&providerOptions.InsecureSkipTLSVerify, "insecure-skip-tls-verify", provider.DefaultOptions.InsecureSkipTLSVerify,
+	rootCmd.Flags().BoolVar(&providerOptions.InsecureSkipTLSVerify, "insecure-skip-tls-verify", providerOptions.InsecureSkipTLSVerify,
 		"Skip TLS verification when connecting to the Omni API.")
-	rootCmd.Flags().DurationVar(&providerOptions.MinRebootInterval, "min-reboot-interval", provider.DefaultOptions.MinRebootInterval,
+	rootCmd.Flags().DurationVar(&providerOptions.MinRebootInterval, "min-reboot-interval", providerOptions.MinRebootInterval,
 		"the minimum interval between reboots of the machine issued by the provider. This is to prevent the provider from issuing reboots too frequently.")
 
 	if constants.IsDebugBuild {
-		rootCmd.Flags().BoolVar(&providerOptions.ClearState, "clear-state", provider.DefaultOptions.ClearState, "Clear the state of the provider on startup.")
+		rootCmd.Flags().BoolVar(&providerOptions.ClearState, "clear-state", providerOptions.ClearState, "Clear the state of the provider on startup.")
 	}
 
-	rootCmd.Flags().BoolVar(&providerOptions.EnableResourceCache, "enable-resource-cache", provider.DefaultOptions.EnableResourceCache,
+	rootCmd.Flags().BoolVar(&providerOptions.EnableResourceCache, "enable-resource-cache", providerOptions.EnableResourceCache,
 		"Enable controller runtime resource cache.")
-	rootCmd.Flags().BoolVar(&providerOptions.WipeWithZeroes, "wipe-with-zeroes", provider.DefaultOptions.WipeWithZeroes,
-		"When wiping a machine, write zeroes to the whole disk instead doing a fast wipe.")
-	rootCmd.Flags().BoolVar(&providerOptions.DisableDHCPProxy, "disable-dhcp-proxy", provider.DefaultOptions.DisableDHCPProxy,
+	rootCmd.Flags().BoolVar(&providerOptions.DisableDHCPProxy, "disable-dhcp-proxy", providerOptions.DisableDHCPProxy,
 		"Disable the DHCP proxy server.")
 
 	// TLS options
-	rootCmd.Flags().BoolVar(&providerOptions.TLS.Enabled, "tls-enabled", provider.DefaultOptions.TLS.Enabled,
+	rootCmd.Flags().BoolVar(&providerOptions.TLS.Enabled, "tls-enabled", providerOptions.TLS.Enabled,
 		"Enable TLS for the API server.")
-	rootCmd.Flags().IntVar(&providerOptions.TLS.APIPort, "tls-api-port", provider.DefaultOptions.TLS.APIPort,
+	rootCmd.Flags().IntVar(&providerOptions.TLS.APIPort, "tls-api-port", providerOptions.TLS.APIPort,
 		"The port to run the API server on when using TLS.")
-	rootCmd.Flags().BoolVar(&providerOptions.TLS.AgentSkipVerify, "tls-agent-skip-verify", provider.DefaultOptions.TLS.AgentSkipVerify,
+	rootCmd.Flags().BoolVar(&providerOptions.TLS.AgentSkipVerify, "tls-agent-skip-verify", providerOptions.TLS.AgentSkipVerify,
 		"Make the Talos agent GRPC client skip TLS verification when connecting to the provider.")
-	rootCmd.Flags().DurationVar(&providerOptions.TLS.CATTL, "tls-ca-ttl", provider.DefaultOptions.TLS.CATTL,
+	rootCmd.Flags().DurationVar(&providerOptions.TLS.CATTL, "tls-ca-ttl", providerOptions.TLS.CATTL,
 		"CA certificate TTL.")
-	rootCmd.Flags().DurationVar(&providerOptions.TLS.CertTTL, "tls-cert-ttl", provider.DefaultOptions.TLS.CertTTL,
+	rootCmd.Flags().DurationVar(&providerOptions.TLS.CertTTL, "tls-cert-ttl", providerOptions.TLS.CertTTL,
 		"TTL for the generated ephemeral certificates using the CA certificate.")
 
 	// RedFish options
-	rootCmd.Flags().BoolVar(&providerOptions.Redfish.UseAlways, "redfish-use-always", provider.DefaultOptions.Redfish.UseAlways,
+	rootCmd.Flags().BoolVar(&providerOptions.Redfish.UseAlways, "redfish-use-always", providerOptions.Redfish.UseAlways,
 		"Always use Redfish for power management.")
-	rootCmd.Flags().BoolVar(&providerOptions.Redfish.UseWhenAvailable, "redfish-use-when-available", provider.DefaultOptions.Redfish.UseWhenAvailable,
+	rootCmd.Flags().BoolVar(&providerOptions.Redfish.UseWhenAvailable, "redfish-use-when-available", providerOptions.Redfish.UseWhenAvailable,
 		"Use Redfish for power management when available.")
-	rootCmd.Flags().BoolVar(&providerOptions.Redfish.UseHTTPS, "redfish-use-https", provider.DefaultOptions.Redfish.UseHTTPS,
+	rootCmd.Flags().BoolVar(&providerOptions.Redfish.UseHTTPS, "redfish-use-https", providerOptions.Redfish.UseHTTPS,
 		"Use HTTPS for Redfish connections.")
-	rootCmd.Flags().BoolVar(&providerOptions.Redfish.InsecureSkipTLSVerify, "redfish-insecure-skip-tls-verify", provider.DefaultOptions.Redfish.InsecureSkipTLSVerify,
+	rootCmd.Flags().BoolVar(&providerOptions.Redfish.InsecureSkipTLSVerify, "redfish-insecure-skip-tls-verify", providerOptions.Redfish.InsecureSkipTLSVerify,
 		"Skip TLS verification when connecting to Redfish.")
-	rootCmd.Flags().IntVar(&providerOptions.Redfish.Port, "redfish-port", provider.DefaultOptions.Redfish.Port,
+	rootCmd.Flags().IntVar(&providerOptions.Redfish.Port, "redfish-port", providerOptions.Redfish.Port,
 		"The port to connect to Redfish.")
-	rootCmd.Flags().BoolVar(&providerOptions.Redfish.SetBootSourceOverrideMode, "redfish-set-boot-source-override-mode", provider.DefaultOptions.Redfish.SetBootSourceOverrideMode,
+	rootCmd.Flags().BoolVar(&providerOptions.Redfish.SetBootSourceOverrideMode, "redfish-set-boot-source-override-mode", providerOptions.Redfish.SetBootSourceOverrideMode,
 		"Set the boot source override mode field when using Redfish for power management. Some Redfish implementations require this field to be unset.")
+
+	// Agent Client options
+	rootCmd.Flags().BoolVar(&providerOptions.AgentClient.WipeWithZeroes, "wipe-with-zeroes", providerOptions.AgentClient.WipeWithZeroes,
+		"When wiping a machine, write zeroes to the whole disk instead doing a fast wipe.")
+	rootCmd.Flags().DurationVar(&providerOptions.AgentClient.CallTimeout, "agent-call-timeout", providerOptions.AgentClient.CallTimeout,
+		"Timeout for agent calls.")
+	rootCmd.Flags().DurationVar(&providerOptions.AgentClient.FastWipeTimeout, "agent-fast-wipe-timeout", providerOptions.AgentClient.FastWipeTimeout,
+		"Timeout for fast wipe operation (without zeroes) call to the agent.")
+	rootCmd.Flags().DurationVar(&providerOptions.AgentClient.ZeroesWipeTimeout, "agent-zeroes-wipe-timeout", providerOptions.AgentClient.ZeroesWipeTimeout,
+		"Timeout for slow wipe operation (with zeroes) call to the agent.")
 }

--- a/internal/provider/agent/options.go
+++ b/internal/provider/agent/options.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package agent
+
+import (
+	"time"
+)
+
+// ClientOptions holds the agent client configuration options.
+type ClientOptions struct {
+	WipeWithZeroes    bool
+	CallTimeout       time.Duration
+	FastWipeTimeout   time.Duration
+	ZeroesWipeTimeout time.Duration
+}
+
+// DefaultClientOptions returns the default client options.
+func DefaultClientOptions() ClientOptions {
+	return ClientOptions{
+		WipeWithZeroes:    false,
+		CallTimeout:       30 * time.Second,
+		FastWipeTimeout:   5 * time.Minute,
+		ZeroesWipeTimeout: 24 * time.Hour,
+	}
+}

--- a/internal/provider/bmc/redfish/options.go
+++ b/internal/provider/bmc/redfish/options.go
@@ -15,11 +15,13 @@ type Options struct {
 }
 
 // DefaultOptions is the default RedFish configuration options.
-var DefaultOptions = Options{
-	UseAlways:                 false,
-	UseWhenAvailable:          true,
-	UseHTTPS:                  true,
-	InsecureSkipTLSVerify:     true,
-	Port:                      443,
-	SetBootSourceOverrideMode: true,
+func DefaultOptions() Options {
+	return Options{
+		UseAlways:                 false,
+		UseWhenAvailable:          true,
+		UseHTTPS:                  true,
+		InsecureSkipTLSVerify:     true,
+		Port:                      443,
+		SetBootSourceOverrideMode: true,
+	}
 }

--- a/internal/provider/options.go
+++ b/internal/provider/options.go
@@ -7,6 +7,7 @@ package provider
 import (
 	"time"
 
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/agent"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/bmc/pxe"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/bmc/redfish"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/ipxe"
@@ -34,11 +35,11 @@ type Options struct {
 	InsecureSkipTLSVerify bool
 	UseLocalBootAssets    bool
 	ClearState            bool
-	WipeWithZeroes        bool
 	DisableDHCPProxy      bool
 
-	TLS     TLSOptions
-	Redfish redfish.Options
+	TLS         TLSOptions
+	Redfish     redfish.Options
+	AgentClient agent.ClientOptions
 
 	MinRebootInterval time.Duration
 }
@@ -53,22 +54,25 @@ type TLSOptions struct {
 }
 
 // DefaultOptions returns the default provider options.
-var DefaultOptions = Options{
-	Name:                   "Bare Metal",
-	Description:            "Bare metal infrastructure provider",
-	ImageFactoryBaseURL:    "https://factory.talos.dev",
-	ImageFactoryPXEBaseURL: "https://pxe.factory.talos.dev",
-	AgentModeTalosVersion:  "v1.9.3",
-	BootFromDiskMethod:     string(ipxe.BootIPXEExit),
-	IPMIPXEBootMode:        string(pxe.BootModeUEFI),
-	APIPort:                50042,
-	MinRebootInterval:      5 * time.Minute,
-	Redfish:                redfish.DefaultOptions,
-	TLS: TLSOptions{
-		Enabled:         false,
-		APIPort:         50043,
-		AgentSkipVerify: false,
-		CATTL:           30 * 365 * 24 * time.Hour, // 30 years
-		CertTTL:         24 * time.Hour,
-	},
+func DefaultOptions() Options {
+	return Options{
+		Name:                   "Bare Metal",
+		Description:            "Bare metal infrastructure provider",
+		ImageFactoryBaseURL:    "https://factory.talos.dev",
+		ImageFactoryPXEBaseURL: "https://pxe.factory.talos.dev",
+		AgentModeTalosVersion:  "v1.9.3",
+		BootFromDiskMethod:     string(ipxe.BootIPXEExit),
+		IPMIPXEBootMode:        string(pxe.BootModeUEFI),
+		APIPort:                50042,
+		MinRebootInterval:      5 * time.Minute,
+		Redfish:                redfish.DefaultOptions(),
+		TLS: TLSOptions{
+			Enabled:         false,
+			APIPort:         50043,
+			AgentSkipVerify: false,
+			CATTL:           30 * 365 * 24 * time.Hour, // 30 years
+			CertTTL:         24 * time.Hour,
+		},
+		AgentClient: agent.DefaultClientOptions(),
+	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -180,7 +180,7 @@ func (p *Provider) Run(ctx context.Context) error {
 	}, p.logger)
 	tftpServer := tftp.NewServer(p.options.APIListenAddress, p.logger.With(zap.String("component", "tftp_server")))
 	bmcAPIAddressReader := bmcapi.NewAddressReader(p.options.APIPowerMgmtStateDir)
-	agentClient := agent.NewClient(agentConnectionEventCh, p.options.WipeWithZeroes, p.logger.With(zap.String("component", "agent_client"))) //nolint:contextcheck // false positive
+	agentClient := agent.NewClient(agentConnectionEventCh, p.options.AgentClient, p.logger.With(zap.String("component", "agent_client"))) //nolint:contextcheck // false positive
 	srvr := server.New(ctx, p.options.APIListenAddress, p.options.APIPort, p.options.TLS.APIPort, p.options.UseLocalBootAssets, certs, configHandler, ipxeHandler,
 		agentClient.TunnelServiceServer(), p.logger.With(zap.String("component", "server")))
 


### PR DESCRIPTION
Allow specifying GRPC call timeouts of agent calls. Fast and slow wipe timeouts can be set separately from the rest of the operations.

Bump fast wipe timeout from 30 seconds to 5 minutes.

Do some refactoring on options structs and functions.

Closes https://github.com/siderolabs/omni-infra-provider-bare-metal/issues/37.