### PR TITLE
fix: do not attempt to reboot if BMC config is not yet set

### DIFF
--- a/internal/provider/bmc/bmc.go
+++ b/internal/provider/bmc/bmc.go
@@ -54,7 +54,7 @@ func NewClientFactory(options ClientFactoryOptions) *ClientFactory {
 // GetClient returns a BMC client for the given bare metal machine.
 func (factory *ClientFactory) GetClient(ctx context.Context, config *resources.BMCConfiguration, logger *zap.Logger) (Client, error) {
 	if config == nil {
-		return nil, fmt.Errorf("BMC config is nil")
+		return nil, fmt.Errorf("cannot get BMC client: config is nil")
 	}
 
 	spec := config.TypedSpec().Value

--- a/internal/provider/controllers/bmc_configuration.go
+++ b/internal/provider/controllers/bmc_configuration.go
@@ -152,7 +152,7 @@ func (helper *bmcConfigurationControllerHelper) transform(ctx context.Context, r
 func (helper *bmcConfigurationControllerHelper) storeUserProvidedBMCConfig(userConfig *infra.BMCConfig, bmcConfiguration *resources.BMCConfiguration, logger *zap.Logger) error {
 	config := userConfig.TypedSpec().Value.Config
 	if config == nil {
-		return fmt.Errorf("bmc config is nil")
+		return fmt.Errorf("user provided BMC config is nil")
 	}
 
 	logger.Info("initialize BMC config from user-provided config")

--- a/internal/provider/controllers/reboot_status.go
+++ b/internal/provider/controllers/reboot_status.go
@@ -91,6 +91,12 @@ func (helper *rebootStatusControllerHelper) transform(ctx context.Context, r con
 		return err
 	}
 
+	if bmcConfiguration == nil {
+		logger.Debug("bmc configuration not found, skip")
+
+		return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("bmc configuration not found")
+	}
+
 	if machineStatus == nil {
 		logger.Debug("machine status not found, skip")
 
@@ -157,7 +163,7 @@ func (helper *rebootStatusControllerHelper) finalizerRemoval(ctx context.Context
 	bmcConfiguration, err := safe.ReaderGetByID[*resources.BMCConfiguration](ctx, r, infraMachine.Metadata().ID())
 	if err != nil {
 		if state.IsNotFoundError(err) {
-			logger.Error("bmc configuration does not exist, probably was removed too early - we cannot reboot")
+			logger.Info("bmc configuration does not exist, skip reboot")
 
 			return nil
 		}


### PR DESCRIPTION
If the BMC configuration is not yet initialized (e.g., machine is not yet accepted, or we couldn't initialize the bmc credentials for some reason), skip reconciliation in RebootStatus controller to prevent it from failing.

Also update returned errors for missing BMC config in multiple places to make them more distinguishable, and update a log statement related to it.