### PR TITLE
fix: do not reboot machines which do not need to be powered on

### DIFF
--- a/internal/provider/controllers/bmc_configuration_test.go
+++ b/internal/provider/controllers/bmc_configuration_test.go
@@ -92,13 +92,7 @@ func TestBMCConfiguration(t *testing.T) {
 
 			rtestutils.Destroy[*infra.BMCConfig](ctx, t, st, []string{bmcConfig.Metadata().ID()})
 
-			var setPowerMgmtRequest pair.Pair[string, *agentpb.SetPowerManagementRequest]
-
-			select {
-			case <-ctx.Done():
-				require.Fail(t, "timeout waiting for SetPowerManagement")
-			case setPowerMgmtRequest = <-setPowerMgmtRequestCh:
-			}
+			setPowerMgmtRequest := requireChReceive(ctx, t, setPowerMgmtRequestCh)
 
 			assert.Equal(t, "test-machine", setPowerMgmtRequest.F1)
 			assert.Equal(t, controllers.IPMIUsername, setPowerMgmtRequest.F2.Ipmi.Username)

--- a/internal/provider/controllers/power_operation.go
+++ b/internal/provider/controllers/power_operation.go
@@ -104,15 +104,12 @@ func (helper *powerOperationControllerHelper) transform(ctx context.Context, r c
 		return xerrors.NewTaggedf[qtransform.SkipReconcileTag]("machine has no power management configuration")
 	}
 
-	installed := machine.IsInstalled(infraMachine, wipeStatus)
-	allocated := infraMachine.TypedSpec().Value.ClusterTalosVersion != ""
-	requiresWipe := machine.RequiresWipe(infraMachine, wipeStatus)
-	requiresPowerOn := allocated || installed || requiresWipe
+	requiresPowerOn := machine.RequiresPowerOn(infraMachine, wipeStatus)
 
 	logger.Info("power operation",
-		zap.Bool("installed", installed),
-		zap.Bool("allocated", allocated),
-		zap.Bool("requires_wipe", requiresWipe),
+		zap.Bool("installed", machine.IsInstalled(infraMachine, wipeStatus)),
+		zap.Bool("allocated", infraMachine.TypedSpec().Value.ClusterTalosVersion != ""),
+		zap.Bool("requires_wipe", machine.RequiresWipe(infraMachine, wipeStatus)),
 		zap.Bool("requires_power_on", requiresPowerOn),
 	)
 

--- a/internal/provider/controllers/power_operation_test.go
+++ b/internal/provider/controllers/power_operation_test.go
@@ -60,18 +60,12 @@ func TestPowerOn(t *testing.T) {
 
 			require.NoError(t, st.Create(ctx, infraMachine))
 
-			select { // expect a SetPXEBootOnce call
-			case mode := <-setPXEBootOnceCh:
-				require.Equal(t, pxeBootMode, mode)
-			case <-ctx.Done():
-				require.Fail(t, "timeout waiting for SetPXEBootOnce")
-			}
+			// expect a SetPXEBootOnce call
+			mode := requireChReceive(ctx, t, setPXEBootOnceCh)
+			require.Equal(t, pxeBootMode, mode)
 
-			select { // expect a PowerOn call
-			case <-powerOnCh:
-			case <-ctx.Done():
-				require.Fail(t, "timeout waiting for PowerOn")
-			}
+			// expect a PowerOn call
+			requireChReceive(ctx, t, powerOnCh)
 
 			rtestutils.AssertResource(ctx, t, st, infraMachine.Metadata().ID(), func(res *resources.PowerOperation, assertion *assert.Assertions) {
 				assertion.Equal(specs.PowerState_POWER_STATE_ON, res.TypedSpec().Value.LastPowerOperation)

--- a/internal/provider/controllers/reboot_status_test.go
+++ b/internal/provider/controllers/reboot_status_test.go
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package controllers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/state"
+	omnispecs "github.com/siderolabs/omni/client/api/omni/specs"
+	"github.com/siderolabs/omni/client/pkg/omni/resources/infra"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni-infra-provider-bare-metal/api/specs"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/bmc/pxe"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/controllers"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/machine"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/resources"
+)
+
+func TestNoRebootWhenPoweredOnNotRequired(t *testing.T) {
+	t.Parallel()
+
+	rebootCh := make(chan struct{}, 8)
+	setPXEBootOnceCh := make(chan pxe.BootMode, 8)
+
+	bmcClientFactory := &bmcClientFactoryMock{
+		bmcClient: &bmcClientMock{
+			poweredOn: true,
+			rebootCh:  rebootCh,
+
+			setPXEBootOnceCh: setPXEBootOnceCh,
+		},
+	}
+
+	asserter := reconcileAsserter{t: t}
+
+	withRuntime(t,
+		func(_ context.Context, _ state.State, rt *runtime.Runtime, _ *zap.Logger) {
+			controller := controllers.NewRebootStatusController(bmcClientFactory, 5*time.Minute, pxe.BootModeUEFI, controllers.RebootStatusControllerOptions{
+				PostTransformFunc: asserter.incrementReconcile,
+			})
+
+			require.NoError(t, rt.RegisterQController(controller))
+		},
+		func(ctx context.Context, st state.State, _ *runtime.Runtime, _ *zap.Logger) {
+			bmcConfiguration := resources.NewBMCConfiguration("test-machine")
+
+			require.NoError(t, st.Create(ctx, bmcConfiguration))
+
+			infraMachine := infra.NewMachine("test-machine")
+			infraMachine.TypedSpec().Value.AcceptanceStatus = omnispecs.InfraMachineConfigSpec_ACCEPTED
+			infraMachine.TypedSpec().Value.WipeId = "test-wipe-id"
+
+			require.NoError(t, st.Create(ctx, infraMachine))
+
+			machineStatus := resources.NewMachineStatus(infraMachine.Metadata().ID())
+			machineStatus.TypedSpec().Value.PowerState = specs.PowerState_POWER_STATE_ON
+			machineStatus.TypedSpec().Value.Initialized = true
+			machineStatus.TypedSpec().Value.AgentAccessible = false
+
+			require.NoError(t, st.Create(ctx, machineStatus))
+
+			// The machine meets the following conditions:
+			// - It is powered on, accepted, initialized, but the agent is not accessible -> mode mismatch.
+			// - Its initial wipe is not done, so it requires a wipe.
+			//   Because it requires a wipe, it needs to stay powered on.
+			// -> The controller is expected to attempt to reboot into the agent mode.
+
+			require.True(t, machine.RequiresPowerOn(infraMachine, nil), "machine should require power on")
+
+			requireChReceive(ctx, t, setPXEBootOnceCh)
+			requireChReceive(ctx, t, rebootCh)
+
+			// Mark the machine as "does not need wiping": its initial wipe is done, and its last wipe ID matches the currently expected wipe ID.
+
+			wipeStatus := resources.NewWipeStatus(infraMachine.Metadata().ID())
+			wipeStatus.TypedSpec().Value.InitialWipeDone = true
+			wipeStatus.TypedSpec().Value.LastWipeId = infraMachine.TypedSpec().Value.WipeId
+
+			// ensure that we had at least one reconciliation
+			numReconcilesBefore := asserter.requireNotZero(ctx)
+
+			require.NoError(t, st.Create(ctx, wipeStatus))
+
+			// At this point, the machine is not needed to be powered on,
+			// as it is neither allocated, nor installed, nor requires a wipe.
+			require.False(t, machine.RequiresPowerOn(infraMachine, wipeStatus), "machine should not require power on")
+
+			// wait for a new reconciliation to happen
+			asserter.requireReconcile(ctx, numReconcilesBefore)
+
+			require.Empty(t, rebootCh, "reboot channel should be empty, no reboot should be issued")
+			require.Empty(t, setPXEBootOnceCh, "setPXEBootOnce channel should be empty, no PXE boot mode should be set")
+		},
+	)
+}

--- a/internal/provider/machine/machine.go
+++ b/internal/provider/machine/machine.go
@@ -100,3 +100,12 @@ func RequiredBootMode(infraMachine *infra.Machine, bmcConfiguration *resources.B
 func RequiresPXEBoot(requiredBootMode BootMode) bool {
 	return requiredBootMode == BootModeAgentPXE || requiredBootMode == BootModeTalosPXE
 }
+
+// RequiresPowerOn returns true if the machine requires to be powered on.
+func RequiresPowerOn(infraMachine *infra.Machine, wipeStatus *resources.WipeStatus) bool {
+	allocated := infraMachine.TypedSpec().Value.ClusterTalosVersion != ""
+	installed := IsInstalled(infraMachine, wipeStatus)
+	requiresWipe := RequiresWipe(infraMachine, wipeStatus)
+
+	return allocated || installed || requiresWipe
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -208,7 +208,7 @@ func (p *Provider) Run(ctx context.Context) error {
 		controllers.NewInfraMachineStatusController(parsedMachineLabels),
 		controllers.NewBMCConfigurationController(agentClient, bmcAPIAddressReader),
 		controllers.NewPowerOperationController(time.Now, bmcClientFactory, p.options.MinRebootInterval, pxeBootMode),
-		controllers.NewRebootStatusController(bmcClientFactory, p.options.MinRebootInterval, pxeBootMode),
+		controllers.NewRebootStatusController(bmcClientFactory, p.options.MinRebootInterval, pxeBootMode, controllers.RebootStatusControllerOptions{}),
 		controllers.NewWipeStatusController(agentClient),
 	} {
 		if err = cosiRuntime.RegisterQController(qController); err != nil {


### PR DESCRIPTION
Fix a bug where:
1. A machine is accepted on Omni and is powered off by the provider.
2. The reboot controller wakes up by a change on MachineStatus, as `AgentAccessible` and/or `PowerState` fields get updated by the polling mechanism.
 3. It decides the machine needs to be in the agent mode but detects that the agent is not accessible.
 4. It issues a reboot.
 5. After the machine boots up again, PowerOperationController decides it can be powered off, and powers off the machine again. Machine enters a reboot loop.