### PR TITLE
fix: connect the ipmi client before using it

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ If you would like to deploy the provider in your environment please [see the off
 To run the provider, you need:
 
 - A running Omni instance
-- An Omni infra provider service account matching the ID you'll use with this provider (`bare-metal` by default).
+- An infra provider created in Omni, matching the ID you'll use with this provider (`bare-metal` by default).
   To create it, run:
 
   ```bash
-  omnictl serviceaccount create --use-user-role=false --role=InfraProvider infra-provider:bare-metal
+  omnictl infraprovider create bare-metal
   ```
 
   Replace `bare-metal` with your desired provider ID.
@@ -59,7 +59,7 @@ For local development using Talos running on QEMU, follow these steps:
    docker pull 127.0.0.1:5005/siderolabs/omni-infra-provider-bare-metal:local-dev
    ```
 
-6. Start the provider with your Omni API address and service account credentials:
+6. Start the provider with your Omni API address and the infra provider service account credentials:
 
    ```bash
    export OMNI_ENDPOINT=<your-omni-api-address>

--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -154,8 +154,8 @@ docker run -d --network host \
   --embedded-discovery-service-snapshots-enabled=false \
   --create-initial-service-account \
   --initial-service-account-key-path=/artifacts/key \
-  --join-tokens-mode=strict \
   "${REGISTRY_MIRROR_FLAGS[@]}"
+#  --join-tokens-mode=strict \ # todo: bring back
 
 docker logs -f omni &
 

--- a/internal/provider/bmc/bmc.go
+++ b/internal/provider/bmc/bmc.go
@@ -81,7 +81,7 @@ func (factory *ClientFactory) GetClient(ctx context.Context, config *resources.B
 		return &loggingClient{client: redfishClient, logger: logger}, nil
 	}
 
-	ipmiClient, err := ipmi.NewClient(spec.Ipmi)
+	ipmiClient, err := ipmi.NewClient(ctx, spec.Ipmi)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/controllers/reboot_status.go
+++ b/internal/provider/controllers/reboot_status.go
@@ -140,8 +140,6 @@ func (helper *rebootStatusControllerHelper) transform(ctx context.Context, r con
 	)
 
 	if requiresReboot {
-		logger.Info("reboot machine to switch boot mode")
-
 		return helper.reboot(ctx, infraMachine, bmcConfiguration, powerOperation, requiresPXEBoot, rebootStatus, logger)
 	}
 
@@ -230,6 +228,8 @@ func (helper *rebootStatusControllerHelper) reboot(ctx context.Context,
 
 		return controller.NewRequeueInterval(helper.minRebootInterval - timeSinceLastPowerOn + time.Second)
 	}
+
+	logger.Info("reboot machine to switch boot mode")
 
 	bmcClient, err := helper.bmcClientFactory.GetClient(ctx, bmcConfiguration, logger)
 	if err != nil {

--- a/internal/provider/options.go
+++ b/internal/provider/options.go
@@ -65,7 +65,7 @@ func DefaultOptions() Options {
 		BootFromDiskMethod:     string(ipxe.BootIPXEExit),
 		IPMIPXEBootMode:        string(pxe.BootModeUEFI),
 		APIPort:                50042,
-		MinRebootInterval:      5 * time.Minute,
+		MinRebootInterval:      15 * time.Minute,
 		Redfish:                redfish.DefaultOptions(),
 		TLS: TLSOptions{
 			Enabled:         false,


### PR DESCRIPTION
We forgot to connect the IPMI client, causing IPMI calls to fail. Call Fix ti by calling `.Connect` in the client.

Additionally:
- Make the client close timeout to be the same as the timeout it uses for UDP exchanges.
- Increase the min reboot interval to 15 minutes - on some bare metal machines, 5 minutes was too aggressive, causing the machines to be rebooted every 5 minutes, not giving them enough time to boot into the agent and get wiped.