### PR TITLE
feat: allow providing own ca cert and self-issued certs

### DIFF
--- a/internal/provider/machineconfig/machineconfig.go
+++ b/internal/provider/machineconfig/machineconfig.go
@@ -29,7 +29,7 @@ import (
 func Build(ctx context.Context, r controller.Reader, certs *tls.Certs) ([]byte, error) {
 	var extraDocs []config.Document
 
-	if certs != nil {
+	if certs != nil && certs.CACertPEM != "" {
 		trustedRootsConfig := security.NewTrustedRootsConfigV1Alpha1()
 		trustedRootsConfig.MetaName = "infra-provider-ca"
 		trustedRootsConfig.Certificates = certs.CACertPEM

--- a/internal/provider/options.go
+++ b/internal/provider/options.go
@@ -11,6 +11,7 @@ import (
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/bmc/pxe"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/bmc/redfish"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/ipxe"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/tls"
 )
 
 // Options contains the provider options.
@@ -28,7 +29,12 @@ type Options struct {
 	BootFromDiskMethod     string
 	IPMIPXEBootMode        string
 	MachineLabels          []string
-	APIPort                int
+
+	TLS               tls.Options
+	AgentClient       agent.ClientOptions
+	Redfish           redfish.Options
+	APIPort           int
+	MinRebootInterval time.Duration
 
 	EnableResourceCache   bool
 	AgentTestMode         bool
@@ -37,21 +43,6 @@ type Options struct {
 	ClearState            bool
 	DisableDHCPProxy      bool
 	SecureBootEnabled     bool
-
-	TLS         TLSOptions
-	Redfish     redfish.Options
-	AgentClient agent.ClientOptions
-
-	MinRebootInterval time.Duration
-}
-
-// TLSOptions contains the TLS options.
-type TLSOptions struct {
-	APIPort         int
-	CATTL           time.Duration
-	CertTTL         time.Duration
-	Enabled         bool
-	AgentSkipVerify bool
 }
 
 // DefaultOptions returns the default provider options.
@@ -67,7 +58,7 @@ func DefaultOptions() Options {
 		APIPort:                50042,
 		MinRebootInterval:      15 * time.Minute,
 		Redfish:                redfish.DefaultOptions(),
-		TLS: TLSOptions{
+		TLS: tls.Options{
 			Enabled:         false,
 			APIPort:         50043,
 			AgentSkipVerify: false,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -140,9 +140,8 @@ func (p *Provider) Run(ctx context.Context) error {
 
 	var certs *tls.Certs
 
-	tlsOptions := p.options.TLS
-	if tlsOptions.Enabled {
-		if certs, err = tls.Initialize(ctx, omniState, apiAdvertiseAddress, tlsOptions.CATTL, tlsOptions.CertTTL, p.logger); err != nil {
+	if p.options.TLS.Enabled {
+		if certs, err = tls.Initialize(ctx, omniState, apiAdvertiseAddress, p.options.TLS, p.logger); err != nil {
 			return fmt.Errorf("failed to initialize TLS: %w", err)
 		}
 	}


### PR DESCRIPTION
Add a new mode to be able to give the provider a CA cert, a cert and a key to be used in TLS mode.

This allows users to be able to use a single CA for Omni and the provider, and/or use a public CA to sign their certificates.