### PR TITLE
feat: allow making ipxe trust a custom CA certificate

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -184,6 +184,9 @@ func init() {
 		fmt.Sprintf("The TLS key file. "+
 			"If specified, the provider will not generate a CA certificate to issue ephemeral, short-lived TLS certificates, and this will be used instead. "+
 			"When set, --%s is also required. Required if --%s is set.", certFileFlag, caCertFileFlag))
+	rootCmd.Flags().StringVar(&providerOptions.TLS.CustomIPXECACertFile, "tls-custom-ipxe-ca-cert-file", providerOptions.TLS.CustomIPXECACertFile,
+		"Patch iPXE binaries to replace the iPXE root CA with the provided one. "+
+			"It allows users to make iPXE trust their self-hosted image factory instances with self-signed certificates.")
 
 	// RedFish options
 	rootCmd.Flags().BoolVar(&providerOptions.Redfish.UseAlways, "redfish-use-always", providerOptions.Redfish.UseAlways,

--- a/internal/provider/ipxe/patch.go
+++ b/internal/provider/ipxe/patch.go
@@ -6,6 +6,8 @@ package ipxe
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"os"
@@ -94,32 +96,49 @@ func buildInitScript(endpoint string, port int) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// patchBinaries patches iPXE binaries on the fly with the new embedded script.
+// patchBinaries patches iPXE binaries on the fly with the new embedded script and optionally a new CA fingerprint.
 //
 // This relies on special build in `pkgs/ipxe` where a placeholder iPXE script is embedded.
 // EFI iPXE binaries are uncompressed, so these are patched directly.
 // BIOS amd64 undionly.pxe is compressed, so we instead patch uncompressed version and compress it back using zbin.
 // (zbin is built with iPXE).
-func patchBinaries(initScript []byte, logger *zap.Logger) error {
+func patchBinaries(initScript []byte, customCAFile string, logger *zap.Logger) error {
+	var customCAHash []byte
+
+	if customCAFile != "" {
+		logger.Info("load custom CA file", zap.String("file", customCAFile))
+
+		var err error
+		if customCAHash, err = getCAHash(customCAFile); err != nil {
+			return fmt.Errorf("failed to get CA hash from %q: %w", customCAFile, err)
+		}
+
+		logger.Info("loaded custom CA file", zap.String("file", customCAFile))
+	}
+
 	for _, name := range []string{"ipxe", "snp"} {
-		if err := patchScript(
+		if err := patchFile(
 			fmt.Sprintf(constants.IPXEPath+"/amd64/%s.efi", name),
 			fmt.Sprintf(constants.TFTPPath+"/%s.efi", name),
 			initScript,
+			customCAHash,
+			logger,
 		); err != nil {
 			return fmt.Errorf("failed to patch %q: %w", name, err)
 		}
 
-		if err := patchScript(
+		if err := patchFile(
 			fmt.Sprintf(constants.IPXEPath+"/arm64/%s.efi", name),
 			fmt.Sprintf(constants.TFTPPath+"/%s-arm64.efi", name),
 			initScript,
+			customCAHash,
+			logger,
 		); err != nil {
 			return fmt.Errorf("failed to patch %q: %w", name, err)
 		}
 	}
 
-	if err := patchScript(constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.bin", constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.bin.patched", initScript); err != nil {
+	if err := patchFile(constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.bin", constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.bin.patched", initScript, customCAHash, logger); err != nil {
 		return fmt.Errorf("failed to patch undionly.kpxe.bin: %w", err)
 	}
 
@@ -141,7 +160,28 @@ var (
 	placeholderEnd   = []byte("# *PLACEHOLDER END*")
 )
 
-func patchScript(source, destination string, script []byte) error {
+func getCAHash(customCAPEMFile string) ([]byte, error) {
+	pemBytes, err := os.ReadFile(customCAPEMFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read custom CA file %q: %w", customCAPEMFile, err)
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block from %q", customCAPEMFile)
+	}
+
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("expected PEM type 'CERTIFICATE', got %q in %q", block.Type, customCAPEMFile)
+	}
+
+	hash := sha256.Sum256(block.Bytes)
+
+	return hash[:], nil
+}
+
+// patchFile reads a source binary, replaces the script and/or CA placeholder, and writes it to a destination.
+func patchFile(source, destination string, script, customCAHash []byte, logger *zap.Logger) error {
 	contents, err := os.ReadFile(source)
 	if err != nil {
 		return err
@@ -173,11 +213,64 @@ func patchScript(source, destination string, script []byte) error {
 
 	copy(contents[start:end], script)
 
+	if len(customCAHash) > 0 {
+		if err = replaceCA(contents, customCAHash, logger); err != nil {
+			return fmt.Errorf("failed to replace CA in %q: %w", source, err)
+		}
+	}
+
 	if err = os.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
 		return err
 	}
 
 	return os.WriteFile(destination, contents, 0o644)
+}
+
+// ipxeRootCAHash is the 32-byte SHA256 fingerprint of the default iPXE root CA.
+// This is the signature that will be searched for and replaced.
+//
+// It needs to be the same as https://ipxe.org/_media/certs/ca.crt.
+// Also see: https://github.com/ipxe/ipxe/blob/master/src/crypto/rootcert.c#L55-L61
+var ipxeRootCAHash = []byte{
+	0x9f, 0xaf, 0x71, 0x7b, 0x7f, 0x8c, 0xa2, 0xf9, 0x3c, 0x25,
+	0x6c, 0x79, 0xf8, 0xac, 0x55, 0x91, 0x89, 0x5d, 0x66, 0xd1,
+	0xff, 0x3b, 0xee, 0x63, 0x97, 0xa7, 0x0d, 0x29, 0xc6, 0x5e,
+	0xed, 0x1a,
+}
+
+func replaceCA(fileContents, customCAHash []byte, logger *zap.Logger) error {
+	if len(customCAHash) != sha256.Size {
+		return fmt.Errorf("CA hash must be %d bytes, but got %d", sha256.Size, len(customCAHash))
+	}
+
+	startIdx := 0
+	numOccurrences := 0
+
+	for {
+		caStart := bytes.Index(fileContents[startIdx:], ipxeRootCAHash)
+		if caStart == -1 {
+			if startIdx == 0 {
+				return fmt.Errorf("iPXE root CA hash was not found in file")
+			}
+
+			break // no more occurrences found
+		}
+
+		caStart += startIdx // Adjust index to the original fileContents
+		copy(fileContents[caStart:caStart+len(ipxeRootCAHash)], customCAHash)
+
+		startIdx = caStart + len(customCAHash) // Move past this occurrence
+
+		numOccurrences++
+	}
+
+	logger.Info("replaced iPXE root CA with custom CA",
+		zap.String("original_hash", fmt.Sprintf("%x", ipxeRootCAHash)),
+		zap.String("custom_hash", fmt.Sprintf("%x", customCAHash)),
+		zap.Int("occurrences", numOccurrences),
+	)
+
+	return nil
 }
 
 // compressKPXE is equivalent to: ./util/zbin bin/undionly.kpxe.bin bin/undionly.kpxe.zinfo > bin/undionly.kpxe.zbin.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -161,13 +161,12 @@ func (p *Provider) Run(ctx context.Context) error {
 
 	pxeBootEventCh := make(chan controllers.PXEBootEvent)
 
-	ipxeHandler, err := ipxe.NewHandler(imageFactoryClient, machineConfig, p.options.TLS.Enabled, omniState, pxeBootEventCh, ipxe.HandlerOptions{
+	ipxeHandler, err := ipxe.NewHandler(imageFactoryClient, machineConfig, omniState, pxeBootEventCh, ipxe.HandlerOptions{
 		APIAdvertiseAddress: apiAdvertiseAddress,
 		APIPort:             p.options.APIPort,
-		TLSAPIPort:          p.options.TLS.APIPort,
+		TLS:                 p.options.TLS,
 		UseLocalBootAssets:  p.options.UseLocalBootAssets,
 		AgentTestMode:       p.options.AgentTestMode,
-		AgentTLSSkipVerify:  p.options.TLS.AgentSkipVerify,
 		BootFromDiskMethod:  p.options.BootFromDiskMethod,
 	}, p.logger.With(zap.String("component", "ipxe_handler")))
 	if err != nil {

--- a/internal/provider/tls/tls.go
+++ b/internal/provider/tls/tls.go
@@ -28,14 +28,15 @@ import (
 
 // Options contains the TLS options.
 type Options struct {
-	CACertFile      string
-	CertFile        string
-	KeyFile         string
-	APIPort         int
-	CATTL           time.Duration
-	CertTTL         time.Duration
-	Enabled         bool
-	AgentSkipVerify bool
+	CACertFile           string
+	CertFile             string
+	KeyFile              string
+	CustomIPXECACertFile string
+	APIPort              int
+	CATTL                time.Duration
+	CertTTL              time.Duration
+	Enabled              bool
+	AgentSkipVerify      bool
 }
 
 // Certs contains the CA certificate and the function to get a new valid certificate signed by the CA.


### PR DESCRIPTION
Just like how we patch the ipxe script in the ipxe binary, we can now also patch the trusted ipxe root CA with a custom one. This can be useful for using self-hosted image factory instances with self-signed CAs.