### PR TITLE
feat: add AMI FutureState fallback for boot settings configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/docker v28.3.2+incompatible // indirect
+	github.com/docker/docker v28.3.3+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/docker/cli v28.3.2+incompatible h1:mOt9fcLE7zaACbxW1GeS65RI67wIJrTnqS
 github.com/docker/cli v28.3.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v28.3.2+incompatible h1:wn66NJ6pWB1vBZIilP8G3qQPqHy5XymfYn5vsqeA5oA=
-github.com/docker/docker v28.3.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
+github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/internal/provider/bmc/redfish/redfish.go
+++ b/internal/provider/bmc/redfish/redfish.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/siderolabs/gen/xslices"
@@ -106,7 +107,17 @@ func (c *Client) SetPXEBootOnce(ctx context.Context, mode pxe.BootMode) error {
 			}
 		}
 
-		return system.SetBoot(boot)
+		if err = system.SetBoot(boot); err != nil {
+			if c.isAMIFutureStateError(err) {
+				c.logger.Debug("attempting AMI FutureState workaround for boot settings")
+
+				return c.setBootAMIFutureState(client, system, boot)
+			}
+
+			return err
+		}
+
+		return nil
 	})
 }
 
@@ -143,6 +154,56 @@ func (c *Client) getSystem(client *gofish.APIClient) (*redfish.ComputerSystem, e
 	}
 
 	return systems[0], nil
+}
+
+// isAMIFutureStateError checks if the error is the specific AMI error requiring FutureState URI.
+func (c *Client) isAMIFutureStateError(err error) bool {
+	return strings.Contains(err.Error(), "Ami.1.0.OperationSupportedInFutureStateURI")
+}
+
+// setBootAMIFutureState handles boot setting for AMI BMCs using the FutureState URI.
+func (c *Client) setBootAMIFutureState(client *gofish.APIClient, system *redfish.ComputerSystem, boot redfish.Boot) error {
+	// For AMI BMCs, we need to:
+	// 1. GET the current FutureState to obtain ETag
+	// 2. PATCH boot settings to /redfish/v1/Systems/{id}/SD (FutureState URI) with If-Match header
+
+	// Construct the FutureState URI
+	futureStateURI := system.ODataID + "/SD"
+
+	c.logger.Debug("using AMI FutureState URI for boot settings", zap.String("uri", futureStateURI))
+
+	// First, GET the current FutureState to obtain ETag
+	resp, err := client.Get(futureStateURI)
+	if err != nil {
+		return fmt.Errorf("failed to get current FutureState: %w", err)
+	}
+
+	etag := resp.Header.Get("ETag")
+	if etag == "" {
+		return fmt.Errorf("no ETag found in FutureState response")
+	}
+
+	c.logger.Debug("obtained ETag from FutureState", zap.String("etag", etag))
+
+	// PATCH to the FutureState URI with If-Match header
+	headers := map[string]string{
+		"If-Match": etag,
+	}
+
+	// Boot should be a field in the SD object, so we need to wrap it in a Boot object
+	// See https://pubs.lenovo.com/tsm/patch_systems_instance_sd for more details
+	payload := struct {
+		Boot redfish.Boot `json:"Boot"`
+	}{Boot: boot}
+
+	_, err = client.PatchWithHeaders(futureStateURI, payload, headers)
+	if err != nil {
+		return fmt.Errorf("failed to set boot via AMI FutureState URI: %w", err)
+	}
+
+	c.logger.Debug("successfully set boot settings via AMI FutureState URI")
+
+	return nil
 }
 
 // NewClient returns a new Redfish BMC client.


### PR DESCRIPTION
**Disclaimer: I fixed this issue by using Claude Code & Claude Sonnet 4. Code is human-checked by me.**  


**Problem**

  The Omni bare-metal infrastructure provider fails to set PXE boot configuration on machines with AMI (American Megatrends Inc.) BMC firmware. The provider encounters the following errors when attempting to configure boot settings via the standard Redfish /redfish/v1/Systems/{id} endpoint:

  1. Initial Error: Ami.1.0.OperationSupportedInFutureStateURI - AMI BMCs require boot property modifications to use their proprietary "FutureState" URI (/redfish/v1/Systems/{id}/SD) instead of the standard Systems endpoint.
  2. Follow-up Error: Ami.1.0.PreconditionHeaderMissing - AMI FutureState operations require an ETag precondition header to prevent concurrent modification conflicts.

  This prevents machines with AMI firmware from properly booting into PXE mode for OS installation or recovery operations.

  **Root Cause**

  AMI BMC firmware deviates from standard Redfish behavior by:
  - Routing boot property writes to a vendor-specific "FutureState" URI
  - Requiring ETag-based optimistic locking for all FutureState modifications
  - Mandating a system reset after boot configuration changes (soft reboots don't apply the override)

  **Solution**

  Implemented an automatic fallback mechanism in the Redfish client that detects AMI-specific errors and retries boot configuration using the correct AMI workflow:

  1. Added isAMIFutureStateError() method that identifies the relevant AMI error code
  2. AMI-Specific Workflow: Added setBootAMIFutureState() method that implements the proper AMI sequence:
    - GET the FutureState URI to obtain current ETag
    - PATCH boot settings to FutureState URI with If-Match header
    - Reset system to apply changes (handled by calling controller)
  3. Seamless Fallback: Modified SetPXEBootOnce() to automatically retry with AMI workflow when standard approach fails

  **Code Changes**

  File: internal/provider/bmc/redfish/redfish.go

  - Added AMI error detection logic
  - Implemented ETag-aware FutureState boot configuration
  - Added automatic fallback from standard Redfish to AMI-specific workflow
  - Maintained backward compatibility with non-AMI BMCs

  **Testing**

  - All existing unit tests pass
  - Code passes linting and formatting checks
  - Backward compatibility verified for non-AMI BMCs
  - Resolves boot configuration failures on AMI-based systems