### PR TITLE
fix: write boot filename to BOOTP header for U-Boot ProxyDHCP

### DIFF
--- a/internal/provider/dhcp/proxy.go
+++ b/internal/provider/dhcp/proxy.go
@@ -306,22 +306,35 @@ func offerDHCP(req *dhcpv4.DHCPv4, apiAdvertiseAddress string, apiPort int, fwty
 		resp.UpdateOption(dhcpv4.OptClassIdentifier("PXEClient"))
 	}
 
+	// For the standard PXE TFTP firmware types below, the boot filename is also written to the BOOTP
+	// `file` header field in addition to DHCP option 67. U-Boot's ProxyDHCP code path reads the filename
+	// from the header directly and never processes DHCP options, so without this the BOOTP file field
+	// would be empty. iPXE and HTTP-boot firmwares are not included here since they process DHCP options
+	// correctly.
 	switch fwtype {
 	case FirmwareX86PC:
 		// This is completely standard PXE: just load a file from TFTP.
 		resp.UpdateOption(dhcpv4.OptTFTPServerName(serverIP.String()))
-		resp.UpdateOption(dhcpv4.OptBootFileName("undionly.kpxe"))
+		resp.BootFileName = "undionly.kpxe"
+		resp.UpdateOption(dhcpv4.OptBootFileName(resp.BootFileName))
 	case FirmwareX86Ipxe:
 		// Almost standard PXE, but the boot filename needs to be a URL.
-		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("tftp://%s/undionly.kpxe", serverIP)))
+		urlHost := serverIP.String()
+		if serverIP.To4() == nil { // IPv6 host must be bracketed in a URL authority per RFC 3986
+			urlHost = "[" + urlHost + "]"
+		}
+
+		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("tftp://%s/undionly.kpxe", urlHost)))
 	case FirmwareX86EFI:
 		// This is completely standard PXE: just load a file from TFTP.
 		resp.UpdateOption(dhcpv4.OptTFTPServerName(serverIP.String()))
-		resp.UpdateOption(dhcpv4.OptBootFileName("snp.efi"))
+		resp.BootFileName = "snp.efi"
+		resp.UpdateOption(dhcpv4.OptBootFileName(resp.BootFileName))
 	case FirmwareARMEFI:
 		// This is completely standard PXE: just load a file from TFTP.
 		resp.UpdateOption(dhcpv4.OptTFTPServerName(serverIP.String()))
-		resp.UpdateOption(dhcpv4.OptBootFileName("snp-arm64.efi"))
+		resp.BootFileName = "snp-arm64.efi"
+		resp.UpdateOption(dhcpv4.OptBootFileName(resp.BootFileName))
 	case FirmwareX86HTTP:
 		// This is completely standard HTTP-boot: just load a file from HTTP.
 		resp.UpdateOption(dhcpv4.OptBootFileName(fmt.Sprintf("http://%s/tftp/amd64/snp.efi", ipPort)))

--- a/internal/provider/dhcp/proxy_test.go
+++ b/internal/provider/dhcp/proxy_test.go
@@ -90,6 +90,7 @@ func TestOfferDHCP(t *testing.T) {
 
 		assert.Equal(t, dhcpv4.MessageTypeOffer, resp.MessageType())
 		assert.Equal(t, "snp.efi", resp.BootFileNameOption())
+		assert.Equal(t, "snp.efi", resp.BootFileName)
 		assert.NotNil(t, resp.GetOneOption(dhcpv4.OptionClassIdentifier))
 	})
 
@@ -102,6 +103,7 @@ func TestOfferDHCP(t *testing.T) {
 
 		assert.Equal(t, dhcpv4.MessageTypeAck, resp.MessageType())
 		assert.Equal(t, "snp.efi", resp.BootFileNameOption())
+		assert.Equal(t, "snp.efi", resp.BootFileName)
 		assert.NotNil(t, resp.GetOneOption(dhcpv4.OptionClassIdentifier))
 	})
 
@@ -109,12 +111,13 @@ func TestOfferDHCP(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
-			wantFile string
-			fwtype   dhcp.Firmware
+			wantFile      string
+			wantBOOTPFile string // BOOTP `file` header (resp.BootFileName); empty when only DHCP option 67 is set.
+			fwtype        dhcp.Firmware
 		}{
-			{fwtype: dhcp.FirmwareX86PC, wantFile: "undionly.kpxe"},
-			{fwtype: dhcp.FirmwareX86EFI, wantFile: "snp.efi"},
-			{fwtype: dhcp.FirmwareARMEFI, wantFile: "snp-arm64.efi"},
+			{fwtype: dhcp.FirmwareX86PC, wantFile: "undionly.kpxe", wantBOOTPFile: "undionly.kpxe"},
+			{fwtype: dhcp.FirmwareX86EFI, wantFile: "snp.efi", wantBOOTPFile: "snp.efi"},
+			{fwtype: dhcp.FirmwareARMEFI, wantFile: "snp-arm64.efi", wantBOOTPFile: "snp-arm64.efi"},
 			{fwtype: dhcp.FirmwareX86Ipxe, wantFile: "tftp://192.168.1.100/undionly.kpxe"},
 			{fwtype: dhcp.FirmwareX86HTTP, wantFile: "http://192.168.1.100:50042/tftp/amd64/snp.efi"},
 			{fwtype: dhcp.FirmwareARMHTTP, wantFile: "http://192.168.1.100:50042/tftp/arm64/snp.efi"},
@@ -123,6 +126,30 @@ func TestOfferDHCP(t *testing.T) {
 		for _, tt := range tests {
 			req := newPXEPacket(t, dhcpv4.MessageTypeDiscover)
 			resp, err := dhcp.OfferDHCP(req, apiAddr, apiPort, tt.fwtype, dhcp.Port67)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantFile, resp.BootFileNameOption(), "firmware type %d option 67", tt.fwtype)
+			assert.Equal(t, tt.wantBOOTPFile, resp.BootFileName, "firmware type %d BOOTP file header", tt.fwtype)
+		}
+	})
+
+	t.Run("URL-based boot filenames bracket IPv6 advertise addresses", func(t *testing.T) {
+		t.Parallel()
+
+		const ipv6Addr = "2001:db8::1"
+
+		tests := []struct {
+			wantFile string
+			fwtype   dhcp.Firmware
+		}{
+			{fwtype: dhcp.FirmwareX86Ipxe, wantFile: "tftp://[2001:db8::1]/undionly.kpxe"},
+			{fwtype: dhcp.FirmwareX86HTTP, wantFile: "http://[2001:db8::1]:50042/tftp/amd64/snp.efi"},
+			{fwtype: dhcp.FirmwareARMHTTP, wantFile: "http://[2001:db8::1]:50042/tftp/arm64/snp.efi"},
+		}
+
+		for _, tt := range tests {
+			req := newPXEPacket(t, dhcpv4.MessageTypeDiscover)
+			resp, err := dhcp.OfferDHCP(req, ipv6Addr, apiPort, tt.fwtype, dhcp.Port67)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantFile, resp.BootFileNameOption(), "firmware type %d", tt.fwtype)


### PR DESCRIPTION
U-Boot's ProxyDHCP code path reads the boot filename from the raw BOOTP `file` header field and never processes DHCP options, so populating only option 67 left the field empty and U-Boot could not boot. Also set the BOOTP header field for the TFTP-based firmware types.

Also bracket IPv6 hosts in the iPXE `tftp://` boot URL so the URL is well-formed per RFC 3986.

The issue was originally reported and fixed on the booter repo at siderolabs/booter#11 (commit siderolabs/booter@16e70c7), but it applies here too since the DHCP proxy code was shared with this project.

Co-authored-by: Ryan Persée <98691129+rpersee@users.noreply.github.com>
Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>