### PR TITLE
fix: don't stall boot.ipxe requests when many nodes PXE boot at once

### DIFF
--- a/internal/provider/ipxe/export_test.go
+++ b/internal/provider/ipxe/export_test.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ipxe
+
+import (
+	"github.com/cosi-project/runtime/pkg/controller"
+	"go.uber.org/zap"
+
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/controllers"
+)
+
+// BootScriptName exposes the boot script path to tests.
+var BootScriptName = bootScriptName
+
+// NewTestHandler builds a Handler with only the fields needed to exercise the boot path in ServeHTTP.
+func NewTestHandler(imageFactoryClient ImageFactoryClient, reader controller.Reader,
+	pxeBootEventCh chan<- controllers.PXEBootEvent, logger *zap.Logger,
+) *Handler {
+	return &Handler{
+		imageFactoryClient: imageFactoryClient,
+		reader:             reader,
+		pxeBootEventCh:     pxeBootEventCh,
+		logger:             logger,
+	}
+}

--- a/internal/provider/ipxe/handler.go
+++ b/internal/provider/ipxe/handler.go
@@ -139,6 +139,8 @@ func (handler *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// set Content-Length so net/http sends the body as-is rather than chunked, which would hold the closing chunk until the handler returns
+	w.Header().Set("Content-Length", strconv.Itoa(len(decision.body)))
 	w.WriteHeader(decision.statusCode)
 
 	if _, err = w.Write([]byte(decision.body)); err != nil {
@@ -147,10 +149,16 @@ func (handler *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// flush now so the machine gets the script without waiting for the handler to return
+	if err = http.NewResponseController(w).Flush(); err != nil {
+		handler.logger.Error("failed to flush response", zap.Error(err))
+	}
+
+	// non-blocking send so the request never waits on the controller; the channel is buffered to absorb bursts
 	select {
-	case <-ctx.Done():
-		handler.logger.Error("failed to send PXE boot event", zap.String("uuid", uuid))
 	case handler.pxeBootEventCh <- controllers.PXEBootEvent{MachineID: uuid}:
+	default:
+		handler.logger.Warn("dropped PXE boot event, channel full", zap.String("uuid", uuid))
 	}
 }
 

--- a/internal/provider/ipxe/handler_test.go
+++ b/internal/provider/ipxe/handler_test.go
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ipxe_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/controllers"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/ipxe"
+)
+
+// stubImageFactory returns a fixed PXE URL so the agent-mode boot path produces a body without network access.
+type stubImageFactory struct{}
+
+func (stubImageFactory) SchematicIPXEURL(context.Context, bool, string, string, []string, []string) (string, error) {
+	return "https://factory.example/pxe/abc", nil
+}
+
+func serveBoot(ctx context.Context, h *ipxe.Handler, uuid string) *httptest.ResponseRecorder {
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/ipxe/boot.ipxe?uuid="+uuid+"&arch=amd64", nil)
+	req.SetPathValue("script", ipxe.BootScriptName)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	return rec
+}
+
+// TestBootScriptServesScriptAndReportsBootEvent checks that a boot request returns the flushed script with a
+// Content-Length and hands the PXE boot event to the channel.
+func TestBootScriptServesScriptAndReportsBootEvent(t *testing.T) {
+	ch := make(chan controllers.PXEBootEvent, 1)
+	h := ipxe.NewTestHandler(stubImageFactory{}, state.WrapCore(namespaced.NewState(inmem.Build)), ch, zaptest.NewLogger(t))
+
+	rec := serveBoot(t.Context(), h, "machine-0")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, rec.Flushed, "response was not flushed to the client")
+
+	body := rec.Body.String()
+	require.Contains(t, body, "https://factory.example/pxe/abc")
+	require.Equal(t, strconv.Itoa(len(body)), rec.Header().Get("Content-Length"))
+
+	select {
+	case ev := <-ch:
+		require.Equal(t, "machine-0", ev.MachineID)
+	default:
+		t.Fatal("PXE boot event was not delivered to the channel")
+	}
+}
+
+// TestBootScriptDoesNotBlockUnderHerd fires many concurrent boot requests at a channel that nothing drains,
+// mimicking the controller loop tied up polling BMCs. Every request must still return its script promptly; the
+// boot events are dropped by design once the buffer is full.
+func TestBootScriptDoesNotBlockUnderHerd(t *testing.T) {
+	const herd = 300
+
+	ch := make(chan controllers.PXEBootEvent) // unbuffered and undrained: sends can never succeed
+	h := ipxe.NewTestHandler(stubImageFactory{}, state.WrapCore(namespaced.NewState(inmem.Build)), ch, zaptest.NewLogger(t))
+
+	var wg sync.WaitGroup
+
+	recs := make([]*httptest.ResponseRecorder, herd)
+
+	for i := range herd {
+		wg.Go(func() {
+			recs[i] = serveBoot(t.Context(), h, fmt.Sprintf("machine-%d", i))
+		})
+	}
+
+	served := make(chan struct{})
+
+	go func() { wg.Wait(); close(served) }()
+
+	select {
+	case <-served:
+	case <-time.After(5 * time.Second):
+		t.Fatal("boot.ipxe handlers blocked under a thundering herd")
+	}
+
+	for _, rec := range recs {
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "https://factory.example/pxe/abc")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -53,6 +53,9 @@ import (
 //go:embed data/icon.svg
 var icon []byte
 
+// pxeBootEventChBuffer bounds how many PXE boot events can queue while the consumer is busy polling BMCs, so a burst of concurrent boots does not block the iPXE handler.
+const pxeBootEventChBuffer = 1024
+
 // Provider implements the bare metal infra provider.
 type Provider struct {
 	logger *zap.Logger
@@ -160,7 +163,7 @@ func (p *Provider) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to build machine config: %w", err)
 	}
 
-	pxeBootEventCh := make(chan controllers.PXEBootEvent)
+	pxeBootEventCh := make(chan controllers.PXEBootEvent, pxeBootEventChBuffer)
 
 	ipxeHandler, err := ipxe.NewHandler(
 		ctx, imageFactoryClient, machineConfig, omniState, pxeBootEventCh,


### PR DESCRIPTION
When many nodes PXE booted at once, boot.ipxe requests could stall for tens of seconds. The handler wrote the small script body, then blocked sending the PXE boot event on an unbuffered channel whose consumer was busy polling BMCs. Because net/http buffers a small body until the handler returns, the machine never received its script. The handler now sets Content-Length and flushes the response so the script reaches the machine immediately, and it sends the boot event from a goroutine bound to the provider context so the request no longer waits on the controller.

Fixes: #117
