### PR TITLE
test: compress BIOS iPXE binaries with the pure Go zbin port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,12 +143,13 @@ require (
 	github.com/siderolabs/go-procfs v0.1.2 // indirect
 	github.com/siderolabs/go-retry v0.3.3 // indirect
 	github.com/siderolabs/go-talos-support v0.3.0 // indirect
+	github.com/siderolabs/go-zbin v0.0.0-00010101000000-000000000000
 	github.com/siderolabs/proto-codec v0.1.4 // indirect
 	github.com/siderolabs/protoenc v0.2.4 // indirect
 	github.com/siderolabs/siderolink v0.3.16 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
-	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/ulikunitz/xz v0.5.16 // indirect
 	github.com/vishvananda/netlink v1.3.1 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -198,3 +199,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/siderolabs/go-zbin => github.com/utkuozdemir/sidero-go-zbin v0.0.0-20260729113556-720e53961c7d

--- a/go.sum
+++ b/go.sum
@@ -412,8 +412,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8RaCKgVpHZnecvArXvPXcFkM=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=
-github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
-github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.16 h1:ld6NyySjx5lowVKwJvMRLnW5nxKX/xnpSiFYZ/Lxur0=
+github.com/ulikunitz/xz v0.5.16/go.mod h1:H9Rt/W6/Qj27PGauhQc6nfCDy7vHpzsOThBSaYDoEhw=
+github.com/utkuozdemir/sidero-go-zbin v0.0.0-20260729113556-720e53961c7d h1:+BkYgw9BucV10Uwt12gI0OklzIEkYA2qZsB4fqei4fA=
+github.com/utkuozdemir/sidero-go-zbin v0.0.0-20260729113556-720e53961c7d/go.mod h1:shUo0VxDO1KjdbL6t+QZUmx+CJYZI95zf6s7w7dlXWk=
 github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=

--- a/internal/provider/ipxe/handler.go
+++ b/internal/provider/ipxe/handler.go
@@ -341,7 +341,7 @@ func (handler *Handler) consoleKernelArgs(arch string) []string {
 }
 
 // NewHandler creates a new iPXE server.
-func NewHandler(ctx context.Context, imageFactoryClient ImageFactoryClient, machineConfig []byte, r controller.Reader,
+func NewHandler(_ context.Context, imageFactoryClient ImageFactoryClient, machineConfig []byte, r controller.Reader,
 	pxeBootEventCh chan<- controllers.PXEBootEvent, options HandlerOptions, logger *zap.Logger,
 ) (*Handler, error) {
 	bootFromDiskMethod, err := parseBootFromDiskMethod(options.BootFromDiskMethod)
@@ -356,7 +356,7 @@ func NewHandler(ctx context.Context, imageFactoryClient ImageFactoryClient, mach
 
 	logger.Info("patch iPXE binaries")
 
-	if err = patchBinaries(ctx, initScript, options.TLS.CustomIPXECACertFile, logger); err != nil {
+	if err = patchBinaries(initScript, options.TLS.CustomIPXECACertFile, logger); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/ipxe/patch.go
+++ b/internal/provider/ipxe/patch.go
@@ -6,20 +6,17 @@ package ipxe
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"text/template"
 
+	"github.com/siderolabs/go-zbin/zbin"
 	"go.uber.org/zap"
 
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/constants"
-	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/util"
 )
 
 // bootTemplate is embedded into iPXE binary when that binary is sent to the node.
@@ -101,9 +98,8 @@ func buildInitScript(endpoint string, port int) ([]byte, error) {
 //
 // This relies on special build in `pkgs/ipxe` where a placeholder iPXE script is embedded.
 // EFI iPXE binaries are uncompressed, so these are patched directly.
-// BIOS amd64 undionly.pxe is compressed, so we instead patch uncompressed version and compress it back using zbin.
-// (zbin is built with iPXE).
-func patchBinaries(ctx context.Context, initScript []byte, customCAFile string, logger *zap.Logger) error {
+// BIOS amd64 undionly.pxe is compressed, so we instead patch uncompressed version and compress it back.
+func patchBinaries(initScript []byte, customCAFile string, logger *zap.Logger) error {
 	var customCAHash []byte
 
 	if customCAFile != "" {
@@ -143,14 +139,9 @@ func patchBinaries(ctx context.Context, initScript []byte, customCAFile string, 
 		return fmt.Errorf("failed to patch undionly.kpxe.bin: %w", err)
 	}
 
-	if err := compressKPXE(ctx, constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.bin.patched", constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.zinfo",
-		constants.TFTPPath+"/undionly.kpxe", logger); err != nil {
+	if err := compressKPXE(constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.bin.patched", constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.zinfo",
+		constants.TFTPPath+"/undionly.kpxe", constants.TFTPPath+"/undionly.kpxe.0"); err != nil {
 		return fmt.Errorf("failed to compress undionly.kpxe: %w", err)
-	}
-
-	if err := compressKPXE(ctx, constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.bin.patched", constants.IPXEPath+"/amd64/kpxe/undionly.kpxe.zinfo",
-		constants.TFTPPath+"/undionly.kpxe.0", logger); err != nil {
-		return fmt.Errorf("failed to compress undionly.kpxe.0: %w", err)
 	}
 
 	return nil
@@ -275,26 +266,29 @@ func replaceCA(fileContents, customCAHash []byte, logger *zap.Logger) error {
 	return nil
 }
 
-// compressKPXE is equivalent to: ./util/zbin bin/undionly.kpxe.bin bin/undionly.kpxe.zinfo > bin/undionly.kpxe.zbin.
-func compressKPXE(ctx context.Context, binFile, infoFile, outFile string, logger *zap.Logger) error {
-	out, err := os.Create(outFile)
+// compressKPXE compresses the patched BIOS iPXE binary according to its zinfo directive stream and
+// writes the result to each given output file. It is equivalent to running iPXE's zbin tool:
+// ./util/zbin bin/undionly.kpxe.bin bin/undionly.kpxe.zinfo > bin/undionly.kpxe.zbin.
+func compressKPXE(binFile, infoFile string, outFiles ...string) error {
+	bin, err := os.ReadFile(binFile)
 	if err != nil {
 		return err
 	}
 
-	defer util.LogClose(out, logger)
-
-	cmd := exec.CommandContext(ctx, "/bin/zbin", binFile, infoFile)
-	cmd.Stdout = out
-
-	err = cmd.Run()
+	zinfo, err := os.ReadFile(infoFile)
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return fmt.Errorf("zbin failed with exit code %d, stderr: %v", exitErr.ExitCode(), string(exitErr.Stderr))
-		}
+		return err
+	}
 
-		return fmt.Errorf("failed to run zbin: %w", err)
+	out, err := zbin.Compress(bin, zinfo)
+	if err != nil {
+		return fmt.Errorf("failed to compress %q: %w", binFile, err)
+	}
+
+	for _, outFile := range outFiles {
+		if err = os.WriteFile(outFile, out, 0o644); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The BIOS boot binaries are now compressed in-process by the pure Go implementation of the zbin format, instead of executing the compressor tool bundled in the container image.

This is a throwaway branch to exercise the port against the integration test, which PXE-boots machines in BIOS mode and therefore boots the compressed output for real. DO NOT MERGE, the library is consumed from an unmerged branch through a temporary directive.

Part of siderolabs/go-zbin#1.