### PR TITLE
test: bind the advertised PXE boot files to the served files

### DIFF
--- a/internal/provider/constants/constants.go
+++ b/internal/provider/constants/constants.go
@@ -8,4 +8,10 @@ package constants
 const (
 	// IPXEURLPath is the path from which the HTTP server serves the iPXE scripts.
 	IPXEURLPath = "ipxe"
+
+	// ConfigURLPath is the path from which the HTTP server serves the machine configs.
+	ConfigURLPath = "config"
+
+	// AssetsURLPath is the path from which the HTTP server serves the local boot assets.
+	AssetsURLPath = "assets"
 )

--- a/internal/provider/dhcp/export_test.go
+++ b/internal/provider/dhcp/export_test.go
@@ -4,7 +4,4 @@
 
 package dhcp
 
-var (
-	IsBootDHCP = isBootDHCP
-	OfferDHCP  = offerDHCP
-)
+var IsBootDHCP = isBootDHCP

--- a/internal/provider/dhcp/proxy.go
+++ b/internal/provider/dhcp/proxy.go
@@ -172,7 +172,7 @@ func (p *Proxy) handlePacket(port int) func(conn net.PacketConn, peer net.Addr, 
 			return
 		}
 
-		resp, err := offerDHCP(m, p.apiAdvertiseAddress, p.apiPort, fwtype, port)
+		resp, err := OfferDHCP(m, p.apiAdvertiseAddress, p.apiPort, fwtype, port)
 		if err != nil {
 			logger.Error("failed to construct ProxyDHCP response", zap.Error(err))
 
@@ -270,11 +270,11 @@ func validateDHCP(m *dhcpv4.DHCPv4) (fwtype Firmware, err error) {
 	return fwtype, nil
 }
 
-// offerDHCP constructs the DHCP response for a PXE boot request.
+// OfferDHCP constructs the DHCP response for a PXE boot request.
 //
 // On port 67, this is a DHCPOFFER in response to DHCPDISCOVER.
 // On port 4011, this is a DHCPACK in response to DHCPREQUEST.
-func offerDHCP(req *dhcpv4.DHCPv4, apiAdvertiseAddress string, apiPort int, fwtype Firmware, port int) (*dhcpv4.DHCPv4, error) {
+func OfferDHCP(req *dhcpv4.DHCPv4, apiAdvertiseAddress string, apiPort int, fwtype Firmware, port int) (*dhcpv4.DHCPv4, error) {
 	serverIP := net.ParseIP(apiAdvertiseAddress)
 	ipPort := net.JoinHostPort(serverIP.String(), strconv.Itoa(apiPort))
 

--- a/internal/provider/ipxe/boot_contract_test.go
+++ b/internal/provider/ipxe/boot_contract_test.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package ipxe_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/insomniacslk/dhcp/dhcpv4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/dhcp"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/ipxe"
+	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/server"
+)
+
+// TestAdvertisedBootFilesAreServed binds the two halves of the PXE boot contract: every boot file
+// name and URL the DHCP proxy hands out must resolve against the patched files the provider
+// actually serves. The names appear on both sides as independent literals (and a third time in the
+// boot file selection of qemu-up), so this is the test that fails when either side drifts.
+func TestAdvertisedBootFilesAreServed(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	script := []byte("#!ipxe\nchain http://example.org/boot")
+
+	files, err := ipxe.PatchBinaries(script, "", logger)
+	require.NoError(t, err)
+
+	notFound := http.NotFoundHandler()
+	handler := server.NewMultiHandler(notFound, notFound, notFound, "", files, logger)
+
+	offer := func(t *testing.T, fwtype dhcp.Firmware) *dhcpv4.DHCPv4 {
+		t.Helper()
+
+		req, err := dhcpv4.New(
+			dhcpv4.WithMessageType(dhcpv4.MessageTypeRequest),
+			dhcpv4.WithHwAddr([]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}),
+		)
+		require.NoError(t, err)
+
+		resp, err := dhcp.OfferDHCP(req, "192.168.1.100", 50042, fwtype, dhcp.Port4011)
+		require.NoError(t, err)
+
+		return resp
+	}
+
+	t.Run("HTTP boot URLs resolve to patched binaries", func(t *testing.T) {
+		for _, fwtype := range []dhcp.Firmware{dhcp.FirmwareX86HTTP, dhcp.FirmwareARMHTTP} {
+			bootURL, err := url.Parse(offer(t, fwtype).BootFileNameOption())
+			require.NoError(t, err)
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, bootURL.Path, nil))
+
+			require.Equal(t, http.StatusOK, rec.Code, "the advertised URL path %q is not served", bootURL.Path)
+			assert.True(t, bytes.Contains(rec.Body.Bytes(), script), "the file served at %q does not contain the patched script", bootURL.Path)
+		}
+	})
+
+	t.Run("TFTP boot file names are served", func(t *testing.T) {
+		// The TFTP server serves the same files map, and qemu-up hands out the same three names
+		// when PXE-booting via the provisioner DHCP server.
+		for _, tt := range []struct {
+			fwtype       dhcp.Firmware
+			checkPatched bool // the BIOS binary is compressed, so the script is not in it verbatim
+		}{
+			{fwtype: dhcp.FirmwareX86PC},
+			{fwtype: dhcp.FirmwareX86EFI, checkPatched: true},
+			{fwtype: dhcp.FirmwareARMEFI, checkPatched: true},
+		} {
+			name := offer(t, tt.fwtype).BootFileName
+
+			contents, ok := files[name]
+			require.True(t, ok, "the advertised TFTP boot file %q is not among the served files", name)
+			require.NotEmpty(t, contents)
+
+			if tt.checkPatched {
+				assert.True(t, bytes.Contains(contents, script), "the advertised TFTP boot file %q does not contain the patched script", name)
+			}
+		}
+	})
+
+	t.Run("iPXE chain URL file is served", func(t *testing.T) {
+		bootURL, err := url.Parse(offer(t, dhcp.FirmwareX86Ipxe).BootFileNameOption())
+		require.NoError(t, err)
+
+		name := strings.TrimPrefix(bootURL.Path, "/")
+
+		_, ok := files[name]
+		require.True(t, ok, "the advertised iPXE chain file %q is not among the served files", name)
+	})
+}

--- a/internal/provider/ipxe/handler.go
+++ b/internal/provider/ipxe/handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/siderolabs/talos/pkg/machinery/constants"
 	"go.uber.org/zap"
 
+	providerconstants "github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/constants"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/controllers"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/machine"
 	"github.com/siderolabs/omni-infra-provider-bare-metal/internal/provider/resources"
@@ -316,6 +317,12 @@ func (handler *Handler) bootViaFactoryIPXEScript(ctx context.Context, agentMode 
 	return ipxeScript, http.StatusOK, nil
 }
 
+// bootAssetNames returns the boot asset file names for the given architecture. It is the single
+// source of the names, shared by the agent-mode boot script builder and the startup validation.
+func bootAssetNames(arch string) (kernel, initramfs, cmdline string) {
+	return "kernel-" + arch, "initramfs-metal-" + arch + ".xz", "cmdline-metal-" + arch
+}
+
 // ValidateBootAssets checks the local boot assets directory, so a misconfiguration fails at
 // startup instead of when a machine attempts to boot.
 //
@@ -330,7 +337,9 @@ func ValidateBootAssets(dir string, logger *zap.Logger) error {
 	for _, arch := range []string{archAmd64, archArm64} {
 		var archProblems []string
 
-		for _, name := range []string{"kernel-" + arch, "initramfs-metal-" + arch + ".xz", "cmdline-metal-" + arch} {
+		kernel, initramfs, cmdline := bootAssetNames(arch)
+
+		for _, name := range []string{kernel, initramfs, cmdline} {
 			if err := validateBootAssetFile(filepath.Join(dir, name)); err != nil {
 				archProblems = append(archProblems, err.Error())
 			}
@@ -376,11 +385,13 @@ func validateBootAssetFile(path string) error {
 func (handler *Handler) bootAgentModeViaLocalIPXEScript(arch string, kernelArgs []string) (string, int, error) {
 	hostPort := net.JoinHostPort(handler.options.APIAdvertiseAddress, strconv.Itoa(handler.options.APIPort))
 
-	kernel := fmt.Sprintf("http://%s/assets/kernel-%s", hostPort, arch)
-	initramfs := fmt.Sprintf("http://%s/assets/initramfs-metal-%s.xz", hostPort, arch)
+	kernelName, initramfsName, cmdlineName := bootAssetNames(arch)
+
+	kernel := fmt.Sprintf("http://%s/%s/%s", hostPort, providerconstants.AssetsURLPath, kernelName)
+	initramfs := fmt.Sprintf("http://%s/%s/%s", hostPort, providerconstants.AssetsURLPath, initramfsName)
 
 	// read cmdline
-	cmdline, err := os.ReadFile(filepath.Join(handler.options.BootAssetsPath, "cmdline-metal-"+arch))
+	cmdline, err := os.ReadFile(filepath.Join(handler.options.BootAssetsPath, cmdlineName))
 	if err != nil {
 		return "", http.StatusInternalServerError, fmt.Errorf("failed to read cmdline: %w", err)
 	}
@@ -424,7 +435,7 @@ func NewHandler(imageFactoryClient ImageFactoryClient, machineConfig []byte, r c
 	logger.Info("successfully patched iPXE binaries")
 
 	apiHostPort := net.JoinHostPort(options.APIAdvertiseAddress, strconv.Itoa(options.APIPort))
-	talosConfigURL := fmt.Sprintf("http://%s/config?u=${uuid}", apiHostPort)
+	talosConfigURL := fmt.Sprintf("http://%s/%s?u=${uuid}", apiHostPort, providerconstants.ConfigURLPath)
 	defaultKernelArgs := []string{
 		fmt.Sprintf("%s=%s", constants.KernelParamConfig, talosConfigURL),
 	}

--- a/internal/provider/server/server.go
+++ b/internal/provider/server/server.go
@@ -155,12 +155,14 @@ func (s *Server) shutdownOnCancel(ctx context.Context, server *http.Server) erro
 func NewMultiHandler(configHandler, ipxeHandler, grpcHandler http.Handler, assetsDir string, files map[string][]byte, logger *zap.Logger) http.Handler {
 	mux := http.NewServeMux()
 
-	mux.Handle("/config", configHandler)
+	mux.Handle("/"+constants.ConfigURLPath, configHandler)
 	mux.Handle(fmt.Sprintf("/%s/{script}", constants.IPXEURLPath), ipxeHandler)
 	mux.Handle("/tftp/", http.StripPrefix("/tftp/", filesHandler(files)))
 
 	if assetsDir != "" {
-		mux.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir(assetsDir))))
+		assetsPrefix := "/" + constants.AssetsURLPath + "/"
+
+		mux.Handle(assetsPrefix, http.StripPrefix(assetsPrefix, http.FileServer(http.Dir(assetsDir))))
 	}
 
 	loggingMiddleware := func(next http.Handler) http.Handler {


### PR DESCRIPTION
The DHCP proxy advertises boot file names and HTTP boot URLs, and the TFTP and HTTP servers serve the patched iPXE binaries under names that must match. Each side was covered by its own test with its half of the contract hardcoded, so a drift on either side kept all tests green while breaking boots, which has happened before: the HTTP boot URLs pointed at paths nothing served for several releases. A new test resolves every boot file name and URL the proxy actually hands out against the files that are actually served, and fails when either side drifts. The DHCP response builder is exported for it.

The same latent mismatch shape existed for the machine config URL and the local boot assets URLs, which were built from literals that had to match other literals in the HTTP route setup, and for the boot asset file names, which were spelled out in both the agent-mode boot script builder and the startup validation. These now come from shared constants and a single helper, so they cannot drift.